### PR TITLE
Add recommended VS Code extensions/settings

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "esbenp.prettier-vscode",
+    "rust-lang.rust-analyzer",
+    "tamasfe.even-better-toml"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,8 @@
 {
+  // Prettier pretty much needs you to specify all the individual filetypes you
+  // want it to run on, because if you just turn it on by default then it'll try
+  // to also run on other code (e.g. Rust) and break. You can find the list of
+  // Prettier-supported languages here: https://prettier.io/docs/en/index.html
   "[css]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
   "[html]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
   "[javascript]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,1 +1,14 @@
-{ "rust-analyzer.check.command": "clippy" }
+{
+  "[css]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[html]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[javascript]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[json]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[jsonc]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[markdown]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[typescript]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[typescriptreact]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[yaml]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+
+  "editor.formatOnSave": true,
+  "rust-analyzer.check.command": "clippy"
+}


### PR DESCRIPTION
This PR turns on the VS Code "format on save" setting in this repo, and recommends a few extensions to configure formatting for most of the filetypes that we use.