### PR TITLE
Run JS tests in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,5 +25,6 @@ jobs:
       - run: rm -r wasm-bindgen-0.2.84-x86_64-unknown-linux-musl*
       - run: npx prettier --check .
       - run: yarn wasm
+      - run: yarn test run
       - run: yarn build
       - run: yarn vscode


### PR DESCRIPTION
Following up on #2, this PR runs Vitest in CI. We want [`vitest run`](https://vitest.dev/guide/cli.html#vitest-run) here instead of just Vitest, because CI doesn't need watch mode.