### PR TITLE
add subtraction to rust interpreter

### DIFF
--- a/crates/frontend/tests/interp.rs
+++ b/crates/frontend/tests/interp.rs
@@ -9,3 +9,11 @@ fn test_add() {
     let answer = interp(&module, Defn(0), vec![Val::F64(2.), Val::F64(2.)]);
     assert_eq!(answer, vec![Val::F64(4.)]);
 }
+
+#[test]
+fn test_sub() {
+    let src = include_str!("sub.rose");
+    let module = parse(src).unwrap();
+    let answer = interp(&module, Defn(0), vec![Val::F64(2.), Val::F64(2.)]);
+    assert_eq!(answer, vec![Val::F64(0.)]);
+}

--- a/crates/frontend/tests/sub.rose
+++ b/crates/frontend/tests/sub.rose
@@ -1,0 +1,1 @@
+def sub(x: R, y: R): R = x - y

--- a/crates/interp/src/lib.rs
+++ b/crates/interp/src/lib.rs
@@ -68,7 +68,13 @@ pub fn interp(module: &Module, function: Defn, args: Vec<Val>) -> Vec<Val> {
                         }
                     }
                 }
-                Binop::SubReal => todo!(),
+                Binop::SubReal => {
+                    if let Val::F64(b) = stack.pop().unwrap() {
+                        if let Val::F64(a) = stack.pop().unwrap() {
+                            stack.push(Val::F64(a - b));
+                        }
+                    }
+                }
                 Binop::MulReal => {
                     if let Val::F64(b) = stack.pop().unwrap() {
                         if let Val::F64(a) = stack.pop().unwrap() {


### PR DESCRIPTION
This PR adds subtraction to the rust interpreter mirroring addition and multiplication, and test case.