### PR TITLE
Specify Cargo workspace members via glob

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,2 @@
 [workspace]
-members = [
-  "crates/cli",
-  "crates/core",
-  "crates/frontend",
-  "crates/interp",
-  "crates/web",
-]
+members = ["crates/*"]


### PR DESCRIPTION
Not sure why I didn't do this earlier; this just makes it easier to add more crates over time, such as in #9. Docs here: https://doc.rust-lang.org/cargo/reference/workspaces.html#the-members-and-exclude-fields