### PR TITLE
Use curl instead of wget

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,9 +4,9 @@
 
 Make sure to have these tools installed:
 
+- [curl][]
 - [Git][]
 - [Make][]
-- [Wget][]
 - [Rust][]
 - [Node.js][] v16-v18
   - [Yarn][] v1.x
@@ -55,9 +55,9 @@ To run any additional checks:
 make check
 ```
 
+[curl]: https://curl.se/
 [git]: https://git-scm.com/downloads
 [make]: https://en.wikipedia.org/wiki/Make_(software)
 [node.js]: https://nodejs.org/en/download
 [rust]: https://www.rust-lang.org/tools/install
-[wget]: https://en.wikipedia.org/wiki/Wget
 [yarn]: https://classic.yarnpkg.com/lang/en/docs/install

--- a/Makefile
+++ b/Makefile
@@ -63,11 +63,11 @@ test-core: yarn wasm
 
 # fetch encircled icon
 packages/vscode/encircled-rose.png:
-	curl --output-dir packages/vscode https://github.com/rose-lang/rose-icons/raw/efcc218832d65970a47bed597ee11cecd3d1cc3c/png/encircled-rose.png
+	curl -O --output-dir packages/vscode https://github.com/rose-lang/rose-icons/raw/efcc218832d65970a47bed597ee11cecd3d1cc3c/png/encircled-rose.png
 
 # fetch plain icon
 packages/vscode/plain-rose.png:
-	curl --output-dir packages/vscode https://github.com/rose-lang/rose-icons/raw/efcc218832d65970a47bed597ee11cecd3d1cc3c/png/plain-rose.png
+	curl -O --output-dir packages/vscode https://github.com/rose-lang/rose-icons/raw/efcc218832d65970a47bed597ee11cecd3d1cc3c/png/plain-rose.png
 
 # build
 vscode: yarn packages/vscode/encircled-rose.png packages/vscode/plain-rose.png

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,7 @@
 build: packages
 
 # run all tests
-test: yarn wasm
-	cargo test
-	yarn workspace @rose-lang/core test run
+test: test-rust test-js
 
 # run other checks
 check: prettier
@@ -14,7 +12,7 @@ check: prettier
 # do everything
 all: build test check
 
-## Rust
+### Rust
 
 # install additional Rust stuff that we need
 rust:
@@ -31,7 +29,11 @@ wbg: rust
 	cargo build --package=rose-web --target=wasm32-unknown-unknown --release
 	.cargo/bin/wasm-bindgen --target=web --out-dir=packages/wasm/wbg target/wasm32-unknown-unknown/release/rose_web.wasm
 
-## JavaScript
+# run Rust tests
+test-rust:
+	cargo test
+
+### JavaScript
 
 # fetch JavaScript dependencies
 yarn:
@@ -41,17 +43,38 @@ yarn:
 prettier: yarn
 	npx prettier --check .
 
-# build `packages/core/`
-core: yarn wasm
-	yarn workspace @rose-lang/core build
-
-# build `packages/vscode/`
-vscode: yarn
-	yarn workspace rose package
-
-# build `packages/wasm/`
-wasm: yarn bindings wbg
-	yarn workspace @rose-lang/wasm build
-
 # build `packages/`
 packages: core vscode wasm
+
+# run JavaScript tests
+test-js: test-core
+
+## `packages/core`
+
+# build
+core: yarn wasm
+	yarn workspace rose build
+
+# test
+test-core: yarn wasm
+	yarn workspace rose test run
+
+## `packages/vscode`
+
+# fetch encircled icon
+packages/vscode/encircled-rose.png:
+	curl --output-dir packages/vscode https://github.com/rose-lang/rose-icons/raw/efcc218832d65970a47bed597ee11cecd3d1cc3c/png/encircled-rose.png
+
+# fetch plain icon
+packages/vscode/plain-rose.png:
+	curl --output-dir packages/vscode https://github.com/rose-lang/rose-icons/raw/efcc218832d65970a47bed597ee11cecd3d1cc3c/png/plain-rose.png
+
+# build
+vscode: yarn packages/vscode/encircled-rose.png packages/vscode/plain-rose.png
+	yarn workspace rose-vscode build
+
+## `packages/wasm`
+
+# build
+wasm: yarn bindings wbg
+	yarn workspace @rose-lang/wasm build

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@rose-lang/core",
+  "name": "rose",
   "version": "0.0.0",
   "license": "MIT",
   "type": "module",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "rose",
+  "name": "rose-vscode",
   "displayName": "Rose",
   "version": "0.0.0",
   "publisher": "rose-lang",
@@ -45,9 +45,6 @@
     ]
   },
   "scripts": {
-    "package": "vsce package --yarn",
-    "vscode:prepublish": "yarn wget-encircled && yarn wget-plain",
-    "wget-encircled": "wget -nc https://github.com/rose-lang/rose-icons/raw/efcc218832d65970a47bed597ee11cecd3d1cc3c/png/encircled-rose.png",
-    "wget-plain": "wget -nc https://github.com/rose-lang/rose-icons/raw/efcc218832d65970a47bed597ee11cecd3d1cc3c/png/plain-rose.png"
+    "build": "vsce package --yarn"
   }
 }


### PR DESCRIPTION
Resolves #5. [curl](https://curl.se/) is nicer because it's [preinstalled on macOS](https://curl.se/mail/lib-2012-11/0013.html). This PR switches to that and also replaces the `-nc` flag with Make's builtin change tracking.

Since this PR touches that part of the `Makefile`, I also went ahead and renamed our VS Code extension to `rose-vscode` so that it doesn't conflict with the [rose](https://www.npmjs.com/package/rose) package on npm.