### PR TITLE
Replace `Module` with `Rc`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -546,7 +546,6 @@ version = "0.0.0"
 dependencies = [
  "serde",
  "ts-rs",
- "wasm-bindgen",
 ]
 
 [[package]]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -8,7 +8,6 @@ include = ["src/lib.rs"]
 
 [dependencies]
 serde = { version = "1", features = ["derive"], optional = true }
-wasm-bindgen = "0.2"
 
 [dev-dependencies]
 ts-rs = "6.1"

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -48,20 +48,12 @@ pub enum Size {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, Debug)]
 pub enum Type {
-    ///
-    Opaque,
     Bool,
     Int,
     Real,
-    Size {
-        val: Size,
-    },
-    Nat {
-        bound: Size,
-    },
-    Var {
-        id: Var,
-    },
+    Size { val: Size },
+    Nat { bound: Size },
+    Var { id: Var },
 }
 
 #[derive(Debug)]
@@ -188,8 +180,6 @@ pub enum Instr {
 
 #[derive(Debug)]
 pub struct Function<T> {
-    /// Opaque function dependencies.
-    pub opaques: Vec<T>,
     pub params: Vec<Type>,
     pub ret: Vec<Type>,
     pub locals: Vec<Type>,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -72,8 +72,8 @@ pub enum Typexpr {
 }
 
 #[derive(Debug)]
-pub struct Inst<T> {
-    pub def: Rc<Def<Function<T>>>,
+pub struct Inst {
+    pub def: Rc<Def<Function>>,
     /// Generic size parameters.
     pub params: Vec<Size>,
 }
@@ -179,16 +179,16 @@ pub enum Instr {
 }
 
 #[derive(Debug)]
-pub struct Function<T> {
+pub struct Function {
     pub params: Vec<Type>,
     pub ret: Vec<Type>,
     pub locals: Vec<Type>,
-    pub funcs: Vec<Inst<T>>,
+    pub funcs: Vec<Inst>,
     pub body: Vec<Instr>,
 }
 
-impl<T> Function<T> {
-    pub fn get_func(&self, id: Func) -> &Inst<T> {
+impl Function {
+    pub fn get_func(&self, id: Func) -> &Inst {
         &self.funcs[id.0]
     }
 }

--- a/crates/frontend/src/lib.rs
+++ b/crates/frontend/src/lib.rs
@@ -118,7 +118,7 @@ impl<'input> From<ParseError<usize, Token<'input>, (Range<usize>, LexicalError)>
     }
 }
 
-pub fn parse(source: &str) -> Result<rose::Module, Error> {
+pub fn parse(source: &str) -> Result<translate::Module, Error> {
     let lexer = Lexer::new(source);
     let ast = ModuleParser::new().parse(source, lexer)?;
     Ok(translate(ast)?)

--- a/crates/frontend/src/translate.rs
+++ b/crates/frontend/src/translate.rs
@@ -483,7 +483,6 @@ impl<'input> Module<'input> {
                 let mut ctx = FunCtx {
                     m: self,
                     f: ir::Function {
-                        opaques: vec![],
                         params: paramtypes.clone(), // should be a way to do this without `clone`...
                         ret: vec![ret],
                         locals: vec![],

--- a/crates/frontend/src/translate.rs
+++ b/crates/frontend/src/translate.rs
@@ -112,12 +112,12 @@ pub struct Type<'input> {
 #[derive(Debug)]
 pub struct Module<'input> {
     pub types: HashMap<&'input str, Type<'input>>,
-    pub funcs: HashMap<&'input str, Rc<rose::Def<rose::Function<()>>>>,
+    pub funcs: HashMap<&'input str, Rc<rose::Def<rose::Function>>>,
 }
 
 struct FunCtx<'input, 'a> {
     m: &'a Module<'input>,
-    f: ir::Function<()>,
+    f: ir::Function,
     t: Vec<ir::Typexpr>,
     g: HashMap<&'input str, ir::Generic>,
     l: HashMap<&'input str, ir::Local>,
@@ -136,7 +136,7 @@ impl<'input, 'a> FunCtx<'input, 'a> {
         id
     }
 
-    fn newfunc(&mut self, f: ir::Inst<()>) -> ir::Func {
+    fn newfunc(&mut self, f: ir::Inst) -> ir::Func {
         let id = ir::Func(self.f.funcs.len());
         self.f.funcs.push(f);
         id
@@ -179,7 +179,7 @@ impl<'input, 'a> FunCtx<'input, 'a> {
 
     fn unify(
         &mut self,
-        _f: &ir::Def<ir::Function<()>>,
+        _f: &ir::Def<ir::Function>,
         _args: &[ir::Type],
     ) -> Result<(Vec<ir::Size>, ir::Type), TypeError> {
         todo!()

--- a/crates/frontend/src/translate.rs
+++ b/crates/frontend/src/translate.rs
@@ -1,6 +1,6 @@
 use crate::{ast, tokens};
 use rose as ir;
-use std::{collections::HashMap, ops::Range};
+use std::{collections::HashMap, ops::Range, rc::Rc};
 
 #[derive(Debug, thiserror::Error)]
 pub enum TypeError {
@@ -49,15 +49,18 @@ type ParsedTypes<'input> = (
 );
 
 fn parse_types<'input>(
-    lookup: impl Fn(&'input str) -> Option<ir::Typedef>,
+    lookup: impl Fn(&'input str) -> Option<Rc<ir::Def<ir::Typexpr>>>,
     typenames: impl Iterator<Item = ast::Spanned<&'input str>>,
 ) -> Result<ParsedTypes<'input>, TypeError> {
     let mut generics = HashMap::new();
     let mut typevars = vec![];
     let mut types = vec![];
     for typ in typenames {
-        types.push(if let Some(id) = lookup(typ.val) {
-            let typexpr = ir::Typexpr::Typedef { id, params: vec![] };
+        types.push(if let Some(def) = lookup(typ.val) {
+            let typexpr = ir::Typexpr::Typedef {
+                def,
+                params: vec![],
+            };
             let id = ir::Var(typevars.len());
             typevars.push(typexpr);
             ir::Type::Var { id }
@@ -99,15 +102,22 @@ fn parse_types<'input>(
     Ok((generics, typevars, types))
 }
 
-struct ModCtx<'input> {
-    m: ir::Module,
-    t: HashMap<&'input str, (ir::Typedef, Vec<&'input str>)>, // sorted field names
-    f: HashMap<&'input str, ir::Defn>,
+#[derive(Debug)]
+pub struct Type<'input> {
+    pub def: Rc<rose::Def<rose::Typexpr>>,
+    /// Sorted lexicographically.
+    pub fields: Vec<&'input str>,
+}
+
+#[derive(Debug)]
+pub struct Module<'input> {
+    pub types: HashMap<&'input str, Type<'input>>,
+    pub funcs: HashMap<&'input str, Rc<rose::Def<rose::Function<()>>>>,
 }
 
 struct FunCtx<'input, 'a> {
-    ctx: &'a ModCtx<'input>,
-    f: ir::Function,
+    m: &'a Module<'input>,
+    f: ir::Function<()>,
     t: Vec<ir::Typexpr>,
     g: HashMap<&'input str, ir::Generic>,
     l: HashMap<&'input str, ir::Local>,
@@ -126,7 +136,7 @@ impl<'input, 'a> FunCtx<'input, 'a> {
         id
     }
 
-    fn newfunc(&mut self, f: ir::Inst) -> ir::Func {
+    fn newfunc(&mut self, f: ir::Inst<()>) -> ir::Func {
         let id = ir::Func(self.f.funcs.len());
         self.f.funcs.push(f);
         id
@@ -169,7 +179,7 @@ impl<'input, 'a> FunCtx<'input, 'a> {
 
     fn unify(
         &mut self,
-        _f: ir::Defn,
+        _f: &ir::Def<ir::Function<()>>,
         _args: &[ir::Type],
     ) -> Result<(Vec<ir::Size>, ir::Type), TypeError> {
         todo!()
@@ -221,7 +231,7 @@ impl<'input, 'a> FunCtx<'input, 'a> {
                     ir::Type::Var { id } => match self.gettype(id) {
                         ir::Typexpr::Vector { elem, .. } => Ok(*elem),
                         ir::Typexpr::Tuple { .. } => Err(TypeError::IndexTuple),
-                        ir::Typexpr::Typedef { id: _, params: _ } => todo!(),
+                        ir::Typexpr::Typedef { def: _, params: _ } => todo!(),
                     },
                     _ => Err(TypeError::IndexPrimitive { t }),
                 }
@@ -248,7 +258,7 @@ impl<'input, 'a> FunCtx<'input, 'a> {
                             Ok(t)
                         }
                         ir::Typexpr::Tuple { members: _ } => todo!(),
-                        ir::Typexpr::Typedef { id: _, params: _ } => todo!(),
+                        ir::Typexpr::Typedef { def: _, params: _ } => todo!(),
                     },
                     _ => Err(TypeError::MemberPrimitive { t }),
                 }
@@ -263,9 +273,12 @@ impl<'input, 'a> FunCtx<'input, 'a> {
                 for arg in args {
                     types.push(self.typecheck(arg)?);
                 }
-                if let Some(&id) = self.ctx.f.get(func.val) {
-                    let (params, ret) = self.unify(id, &types)?;
-                    let id = self.newfunc(ir::Inst { id, params });
+                if let Some(def) = self.m.funcs.get(func.val) {
+                    let (params, ret) = self.unify(def, &types)?;
+                    let id = self.newfunc(ir::Inst {
+                        def: Rc::clone(def),
+                        params,
+                    });
                     self.f.body.push(ir::Instr::Call { id });
                     Ok(ret)
                 } else {
@@ -428,43 +441,31 @@ impl<'input, 'a> FunCtx<'input, 'a> {
     }
 }
 
-impl<'input> ModCtx<'input> {
-    fn newtype(&mut self, t: ir::Def<ir::Typexpr>) -> ir::Typedef {
-        let id = ir::Typedef(self.m.types.len());
-        self.m.types.push(t);
-        id
-    }
-
-    fn newfunc(&mut self, f: ir::Def<ir::Function>) -> ir::Defn {
-        let id = ir::Defn(self.m.funcs.len());
-        self.m.funcs.push(f);
-        id
-    }
-
+impl<'input> Module<'input> {
     fn define(&mut self, def: ast::Def<'input>) -> Result<(), TypeError> {
         match def {
             ast::Def::Type { name, mut members } => {
                 // TODO: check for duplicate field names
                 members.sort_by_key(|&(name, _)| name); // to ignore field order in literals
                 let (genericnames, typevars, fields) = parse_types(
-                    |s| self.t.get(s).map(|&(i, _)| i),
+                    |s| self.types.get(s).map(|Type { def, .. }| Rc::clone(def)),
                     members.iter().map(|&(_, t)| t),
                 )?;
-                let t = self.newtype(ir::Def {
+                let t = Rc::new(ir::Def {
                     generics: genericnames.len(),
                     types: typevars,
                     def: ir::Typexpr::Tuple { members: fields },
                 });
                 // TODO: check for duplicate type names
-                self.t.insert(
+                self.types.insert(
                     name,
-                    (
-                        t,
-                        members
+                    Type {
+                        def: t,
+                        fields: members
                             .into_iter()
                             .map(|(name, _)| name)
                             .collect::<Vec<_>>(),
-                    ),
+                    },
                 );
             }
             ast::Def::Func {
@@ -474,14 +475,15 @@ impl<'input> ModCtx<'input> {
                 body,
             } => {
                 let (genericnames, typevars, mut paramtypes) = parse_types(
-                    |s| self.t.get(s).map(|&(i, _)| i),
+                    |s| self.types.get(s).map(|Type { def, .. }| Rc::clone(def)),
                     // TODO: handle return type separately from params w.r.t. generics
                     params.iter().map(|&(_, t)| t).chain([typ]),
                 )?;
                 let ret = paramtypes.pop().expect("`parse_types` should preserve len");
                 let mut ctx = FunCtx {
-                    ctx: self,
+                    m: self,
                     f: ir::Function {
+                        opaques: vec![],
                         params: paramtypes.clone(), // should be a way to do this without `clone`...
                         ret: vec![ret],
                         locals: vec![],
@@ -496,30 +498,26 @@ impl<'input> ModCtx<'input> {
                     ctx.bind(t, bind);
                 }
                 ctx.typecheck(body)?; // TODO: ensure this matches `ret`
-                let f = self.newfunc(ir::Def {
+                let f = Rc::new(ir::Def {
                     generics: ctx.g.len(),
                     types: ctx.t,
                     def: ctx.f,
                 });
                 // TODO: check for duplicate function names
-                self.f.insert(name, f);
+                self.funcs.insert(name, f);
             }
         }
         Ok(())
     }
 }
 
-pub fn translate(ast: ast::Module) -> Result<ir::Module, TypeError> {
-    let mut ctx = ModCtx {
-        m: ir::Module {
-            types: vec![],
-            funcs: vec![],
-        },
-        f: HashMap::new(),
-        t: HashMap::new(),
+pub fn translate(ast: ast::Module) -> Result<Module, TypeError> {
+    let mut m = Module {
+        types: HashMap::new(),
+        funcs: HashMap::new(),
     };
     for def in ast.defs {
-        ctx.define(def)?;
+        m.define(def)?;
     }
-    Ok(ctx.m)
+    Ok(m)
 }

--- a/crates/frontend/tests/interp.rs
+++ b/crates/frontend/tests/interp.rs
@@ -1,4 +1,3 @@
-use rose::Defn;
 use rose_frontend::parse;
 use rose_interp::{interp, Val};
 
@@ -6,7 +5,10 @@ use rose_interp::{interp, Val};
 fn test_add() {
     let src = include_str!("add.rose");
     let module = parse(src).unwrap();
-    let answer = interp(&module, Defn(0), vec![Val::F64(2.), Val::F64(2.)]);
+    let answer = interp(
+        module.funcs.get("add").unwrap(),
+        vec![Val::F64(2.), Val::F64(2.)],
+    );
     assert_eq!(answer, vec![Val::F64(4.)]);
 }
 
@@ -14,6 +16,9 @@ fn test_add() {
 fn test_sub() {
     let src = include_str!("sub.rose");
     let module = parse(src).unwrap();
-    let answer = interp(&module, Defn(0), vec![Val::F64(2.), Val::F64(2.)]);
+    let answer = interp(
+        module.funcs.get("sub").unwrap(),
+        vec![Val::F64(2.), Val::F64(2.)],
+    );
     assert_eq!(answer, vec![Val::F64(0.)]);
 }

--- a/crates/interp/src/lib.rs
+++ b/crates/interp/src/lib.rs
@@ -102,7 +102,6 @@ mod tests {
             generics: 0,
             types: vec![],
             def: Function {
-                opaques: vec![],
                 params: vec![Type::Real, Type::Real],
                 ret: vec![Type::Real],
                 locals: vec![],
@@ -120,7 +119,6 @@ mod tests {
             generics: 0,
             types: vec![],
             def: Function {
-                opaques: vec![],
                 params: vec![],
                 ret: vec![Type::Real],
                 locals: vec![],
@@ -132,7 +130,6 @@ mod tests {
             generics: 0,
             types: vec![],
             def: Function {
-                opaques: vec![],
                 params: vec![],
                 ret: vec![Type::Real],
                 locals: vec![Type::Real],

--- a/crates/interp/src/lib.rs
+++ b/crates/interp/src/lib.rs
@@ -10,7 +10,7 @@ pub enum Val {
     Vector(Vec<Rc<Val>>),
 }
 
-pub fn interp<T>(f: &Def<Function<T>>, args: Vec<Val>) -> Vec<Val> {
+pub fn interp(f: &Def<Function>, args: Vec<Val>) -> Vec<Val> {
     let mut locals: Vec<Option<Val>> = vec![None; f.def.locals.len()];
     let mut stack = args;
     for &instr in f.def.body.iter() {
@@ -98,7 +98,7 @@ mod tests {
 
     #[test]
     fn test_two_plus_two() {
-        let f: Def<Function<()>> = Def {
+        let f = Def {
             generics: 0,
             types: vec![],
             def: Function {
@@ -115,7 +115,7 @@ mod tests {
 
     #[test]
     fn test_nested_call() {
-        let f: Rc<Def<Function<()>>> = Rc::new(Def {
+        let f = Rc::new(Def {
             generics: 0,
             types: vec![],
             def: Function {
@@ -126,7 +126,7 @@ mod tests {
                 body: vec![Instr::Real { val: 42. }],
             },
         });
-        let g: Def<Function<()>> = Def {
+        let g = Def {
             generics: 0,
             types: vec![],
             def: Function {

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -1,5 +1,4 @@
-use rose::Module;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
 
 #[wasm_bindgen]
@@ -8,16 +7,20 @@ pub fn initialize() {
 }
 
 #[wasm_bindgen]
-pub fn module_from_js(my_mod_js: JsValue) -> Result<Module, JsValue> {
+#[derive(Serialize, Deserialize)]
+pub struct Body(Vec<rose::Instr>);
+
+#[wasm_bindgen]
+pub fn body_from_js(body_js: JsValue) -> Result<Body, JsValue> {
     // Deserialize the JavaScript object to the Rust Module struct
-    let my_mod: Module = serde_wasm_bindgen::from_value(my_mod_js)?;
-    Ok(my_mod)
+    let body: Body = serde_wasm_bindgen::from_value(body_js)?;
+    Ok(body)
 }
 
 #[wasm_bindgen]
-pub fn module_to_js(my_mod: &Module) -> JsValue {
+pub fn body_to_js(body: &Body) -> JsValue {
     // Serialize the modified Module object back to a JsValue and return the modified JsValue
-    to_js_value(&my_mod).unwrap()
+    to_js_value(&body).unwrap()
 }
 
 fn to_js_value(value: &(impl Serialize + ?Sized)) -> Result<JsValue, serde_wasm_bindgen::Error> {

--- a/packages/core/src/translate.test.ts
+++ b/packages/core/src/translate.test.ts
@@ -1,28 +1,13 @@
-import { module_from_js, module_to_js } from "@rose-lang/wasm";
-import { Module } from "@rose-lang/wasm/core/Module";
+import { body_from_js, body_to_js } from "@rose-lang/wasm";
+import { Instr } from "@rose-lang/wasm/core/Instr";
 import { expect, test } from "vitest";
 
-let myMod: Module = {
-  types: [],
-  funcs: [
-    {
-      generics: 0,
-      types: [],
-      def: {
-        params: ["Real", "Real"],
-        ret: ["Real"],
-        locals: [],
-        funcs: [],
-        body: [{ Binary: { op: "AddReal" } }],
-      },
-    },
-  ],
-};
+let body: Instr[] = [{ Binary: { op: "AddReal" } }];
 
-const modifiedMod = module_from_js(myMod);
-const myMod2 = module_to_js(modifiedMod);
-modifiedMod.free();
+const modifiedBody = body_from_js(body);
+const body2 = body_to_js(modifiedBody);
+modifiedBody.free();
 
 test("test Module type", () => {
-  expect(myMod2).toStrictEqual(myMod);
+  expect(body2).toStrictEqual(body);
 });


### PR DESCRIPTION
Now that we know about [`FinalizationRegistry`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry), we're planning to just represent Rose functions on the Rust side as a digraph of [`Rc`](https://doc.rust-lang.org/std/rc/struct.Rc.html)s, instead of sending over a `Module` every time we want to do something. This PR kicks off that design by making that change to the core IR and fixing all our current downstream usages.