### PR TITLE
Add `make clean`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,30 @@ To run any additional checks:
 make check
 ```
 
+## Clean
+
+Sometimes old build artifacts can hide errors. To clean your build:
+
+```
+make clean
+```
+
+This doesn't clean everything; it keeps around downloaded files and Rust's
+`target` directory. You should be able to run `make all` right after it without
+an Internet connection.
+
+## VS Code
+
+The VS Code extension is built as part of `make` or `make all`, but you can also
+just build it by itself:
+
+```
+make vscode
+```
+
+Then `packages/vscode` will contain a `*.vsix` file that you can install in VS
+Code by right-clicking it and clicking the **Install Extension VSIX** button.
+
 [curl]: https://curl.se/
 [git]: https://git-scm.com/downloads
 [make]: https://en.wikipedia.org/wiki/Make_(software)

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ check: prettier
 	cargo fmt --check
 	cargo clippy
 
+# delete build artifacts, but not dependencies or downloaded files
+clean:
+	git clean -Xdf crates packages -e '!node_modules' -e '!*.png'
+
 # do everything
 all: build test check
 


### PR DESCRIPTION
While working on #18 I ended up with an out-of-date `packages/wasm/dist/bindings` directory since I was deleting types from `crates/core/src/lib.rs`, so I wrote this `make clean` helper to clean up only the troublesome stuff while leaving the slow or downloaded stuff.