### PR TITLE
Call interpreter in JavaScript test

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,5 +14,6 @@
   "[yaml]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
 
   "editor.formatOnSave": true,
+  "evenBetterToml.formatter.alignComments": false,
   "rust-analyzer.check.command": "clippy"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,6 +573,8 @@ name = "rose-interp"
 version = "0.0.0"
 dependencies = [
  "rose",
+ "serde",
+ "ts-rs",
 ]
 
 [[package]]
@@ -581,6 +583,7 @@ version = "0.0.0"
 dependencies = [
  "console_error_panic_hook",
  "rose",
+ "rose-interp",
  "serde",
  "serde-wasm-bindgen",
  "ts-rs",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -10,8 +10,7 @@ include = ["src/lib.rs"]
 serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
-ts-rs = "6.1"
+ts-rs = "6"
 
 [features]
-default = ["serde"]
 serde = ["dep:serde"]

--- a/crates/interp/Cargo.toml
+++ b/crates/interp/Cargo.toml
@@ -6,3 +6,10 @@ edition = "2021"
 
 [dependencies]
 rose = { path = "../core" }
+serde = { version = "1", features = ["derive", "rc"], optional = true }
+
+[dev-dependencies]
+ts-rs = "6"
+
+[features]
+serde = ["dep:serde"]

--- a/crates/interp/src/lib.rs
+++ b/crates/interp/src/lib.rs
@@ -1,6 +1,14 @@
 use rose::{Binop, Def, Function, Instr};
 use std::rc::Rc;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[cfg(test)]
+use ts_rs::TS;
+
+#[cfg_attr(test, derive(TS), ts(export))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq)]
 pub enum Val {
     Bool(bool),

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -10,7 +10,8 @@ crate-type = ["cdylib"]
 [dependencies]
 console_error_panic_hook = "0.1"
 rose = { path = "../core", features = ["serde"] }
+rose-interp = { path = "../interp", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde-wasm-bindgen = "0.4"
 ts-rs = "6"
-wasm-bindgen = "=0.2.84"                          # Must be this version of wbg
+wasm-bindgen = "=0.2.84" # Must be this version of wbg

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use std::rc::Rc;
 use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
 
@@ -11,9 +11,6 @@ fn to_js_value(value: &impl Serialize) -> Result<JsValue, serde_wasm_bindgen::Er
     value.serialize(&serde_wasm_bindgen::Serializer::json_compatible())
 }
 
-#[derive(Deserialize)]
-pub struct Body(Vec<rose::Instr>);
-
 #[wasm_bindgen]
 pub struct Func(Rc<rose::Def<rose::Function>>);
 
@@ -25,7 +22,7 @@ pub fn make_func(
 ) -> Result<Func, serde_wasm_bindgen::Error> {
     let params: Vec<rose::Type> = serde_wasm_bindgen::from_value(param_types)?;
     let locals: Vec<rose::Type> = serde_wasm_bindgen::from_value(local_types)?;
-    let Body(body) = serde_wasm_bindgen::from_value(body)?;
+    let body: Vec<rose::Instr> = serde_wasm_bindgen::from_value(body)?;
     Ok(Func(Rc::new(rose::Def {
         generics: 0,
         types: vec![],

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::rc::Rc;
 use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
 
 #[wasm_bindgen]
@@ -6,23 +7,42 @@ pub fn initialize() {
     std::panic::set_hook(Box::new(console_error_panic_hook::hook));
 }
 
-#[wasm_bindgen]
-#[derive(Serialize, Deserialize)]
+fn to_js_value(value: &impl Serialize) -> Result<JsValue, serde_wasm_bindgen::Error> {
+    value.serialize(&serde_wasm_bindgen::Serializer::json_compatible())
+}
+
+#[derive(Deserialize)]
 pub struct Body(Vec<rose::Instr>);
 
 #[wasm_bindgen]
-pub fn body_from_js(body_js: JsValue) -> Result<Body, JsValue> {
-    // Deserialize the JavaScript object to the Rust Module struct
-    let body: Body = serde_wasm_bindgen::from_value(body_js)?;
-    Ok(body)
+pub struct Func(Rc<rose::Def<rose::Function>>);
+
+#[wasm_bindgen(js_name = "makeFunc")]
+pub fn make_func(
+    param_types: JsValue,
+    local_types: JsValue,
+    body: JsValue,
+) -> Result<Func, serde_wasm_bindgen::Error> {
+    let params: Vec<rose::Type> = serde_wasm_bindgen::from_value(param_types)?;
+    let locals: Vec<rose::Type> = serde_wasm_bindgen::from_value(local_types)?;
+    let Body(body) = serde_wasm_bindgen::from_value(body)?;
+    Ok(Func(Rc::new(rose::Def {
+        generics: 0,
+        types: vec![],
+        def: rose::Function {
+            params,
+            ret: vec![rose::Type::Real],
+            locals,
+            funcs: vec![],
+            body,
+        },
+    })))
 }
 
 #[wasm_bindgen]
-pub fn body_to_js(body: &Body) -> JsValue {
-    // Serialize the modified Module object back to a JsValue and return the modified JsValue
-    to_js_value(&body).unwrap()
-}
-
-fn to_js_value(value: &(impl Serialize + ?Sized)) -> Result<JsValue, serde_wasm_bindgen::Error> {
-    value.serialize(&serde_wasm_bindgen::Serializer::json_compatible())
+pub fn interp(Func(f): &Func, args: JsValue) -> Result<JsValue, serde_wasm_bindgen::Error> {
+    let vals: Vec<rose_interp::Val> = serde_wasm_bindgen::from_value(args)?;
+    let ret = rose_interp::interp(f, vals);
+    assert_eq!(ret.len(), 1);
+    to_js_value(&ret[0])
 }


### PR DESCRIPTION
This PR uses the same optional-feature techniques from #14 to make `rose-interp`'s `Val` type (de)serializable, then exports new functions `makeFunc` and `interp` from `rose-web` to construct and interpret Rose functions, respectively. We then wrap these in a couple better-typed helpers in a simple test file that constructs and calls an addition function while using [`FinalizationRegistry`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry) to avoid memory leaks.

To see that these finalizers do actually get called, you can add a `console.log` to the callback and then wrap the body of the `test` in a loop that runs a hundred thousand times or so.

Incidental change: I got annoyed by [our VS Code TOML extension](https://marketplace.visualstudio.com/items?itemName=tamasfe.even-better-toml) moving comments around, so I disabled that formatter setting in our `.vscode/settings.json` file.