### PR TITLE
Store `Var` ID in `Vector` instr, not just `dim`

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -165,7 +165,7 @@ pub enum Instr {
     Bool { val: bool },
     Int { val: u32 },
     Real { val: f64 },
-    Vector { dim: usize },
+    Vector { id: Var },
     Tuple { id: Var },
     Index,
     Member { id: Member },

--- a/crates/interp/src/lib.rs
+++ b/crates/interp/src/lib.rs
@@ -35,7 +35,7 @@ pub fn interp(f: &Def<Function>, args: Vec<Val>) -> Vec<Val> {
             Instr::Real { val } => {
                 stack.push(Val::F64(val));
             }
-            Instr::Vector { dim: _ } => todo!(),
+            Instr::Vector { id: _ } => todo!(),
             Instr::Tuple { id: _ } => todo!(),
             Instr::Index => todo!(),
             Instr::Member { id: _ } => todo!(),


### PR DESCRIPTION
I was writing up docs on our IR design and realized that it's wrong to store just the vector `dim`ension, because that fails in the empty-vector case and makes it more difficult to resolve type conflicts in the more-than-one-element case, since we have no source-of-truth element type. This PR resolves the issue by using the same solution we use for `Tuple`: just store the `id` of the `Vector` type itself, which holds both the `elem`ent type and the `size`.