### PR TITLE
Flesh out more of the interpreter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,6 +574,7 @@ version = "0.0.0"
 dependencies = [
  "rose",
  "serde",
+ "thiserror",
  "ts-rs",
 ]
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -186,9 +186,3 @@ pub struct Function {
     pub funcs: Vec<Inst>,
     pub body: Vec<Instr>,
 }
-
-impl Function {
-    pub fn get_func(&self, id: Func) -> &Inst {
-        &self.funcs[id.0]
-    }
-}

--- a/crates/frontend/tests/interp.rs
+++ b/crates/frontend/tests/interp.rs
@@ -7,8 +7,10 @@ fn test_add() {
     let module = parse(src).unwrap();
     let answer = interp(
         module.funcs.get("add").unwrap(),
+        &[],
         vec![Val::F64(2.), Val::F64(2.)],
-    );
+    )
+    .unwrap();
     assert_eq!(answer, vec![Val::F64(4.)]);
 }
 
@@ -18,7 +20,9 @@ fn test_sub() {
     let module = parse(src).unwrap();
     let answer = interp(
         module.funcs.get("sub").unwrap(),
+        &[],
         vec![Val::F64(2.), Val::F64(2.)],
-    );
+    )
+    .unwrap();
     assert_eq!(answer, vec![Val::F64(0.)]);
 }

--- a/crates/interp/Cargo.toml
+++ b/crates/interp/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 [dependencies]
 rose = { path = "../core" }
 serde = { version = "1", features = ["derive", "rc"], optional = true }
+thiserror = "1"
 
 [dev-dependencies]
 ts-rs = "6"

--- a/crates/interp/src/lib.rs
+++ b/crates/interp/src/lib.rs
@@ -1,4 +1,4 @@
-use rose::{Binop, Def, Function, Instr};
+use rose::{Binop, Def, Func, Function, Generic, Instr, Local, Size, Type, Unop};
 use std::rc::Rc;
 
 #[cfg(feature = "serde")]
@@ -18,91 +18,340 @@ pub enum Val {
     Vector(Vec<Rc<Val>>),
 }
 
-pub fn interp(f: &Def<Function>, args: Vec<Val>) -> Vec<Val> {
-    let mut locals: Vec<Option<Val>> = vec![None; f.def.locals.len()];
-    let mut stack = args;
-    for &instr in f.def.body.iter() {
-        match instr {
-            Instr::Generic { id: _ } => todo!(),
-            Instr::Get { id } => {
-                stack.push(locals[id.0].as_ref().unwrap().clone());
-            }
-            Instr::Set { id } => {
-                locals[id.0] = stack.pop();
-            }
-            Instr::Bool { val: _ } => todo!(),
-            Instr::Int { val: _ } => todo!(),
-            Instr::Real { val } => {
-                stack.push(Val::F64(val));
-            }
-            Instr::Vector { id: _ } => todo!(),
-            Instr::Tuple { id: _ } => todo!(),
-            Instr::Index => todo!(),
-            Instr::Member { id: _ } => todo!(),
-            Instr::Call { id } => {
-                let g = f.def.get_func(id).def.as_ref();
-                let args = stack.drain(stack.len() - g.def.params.len()..).collect();
-                stack.append(&mut interp(g, args));
-            }
-            Instr::Unary { op: _ } => todo!(),
-            Instr::Binary { op } => match op {
-                Binop::And => todo!(),
-                Binop::Or => todo!(),
-                Binop::EqBool => todo!(),
-                Binop::NeqBool => todo!(),
-                Binop::NeqInt => todo!(),
-                Binop::LtInt => todo!(),
-                Binop::LeqInt => todo!(),
-                Binop::EqInt => todo!(),
-                Binop::GtInt => todo!(),
-                Binop::GeqInt => todo!(),
-                Binop::NeqReal => todo!(),
-                Binop::LtReal => todo!(),
-                Binop::LeqReal => todo!(),
-                Binop::EqReal => todo!(),
-                Binop::GtReal => todo!(),
-                Binop::GeqReal => todo!(),
-                Binop::AddInt => todo!(),
-                Binop::SubInt => todo!(),
-                Binop::MulInt => todo!(),
-                Binop::DivInt => todo!(),
-                Binop::Mod => todo!(),
-                Binop::AddReal => {
-                    if let Val::F64(b) = stack.pop().unwrap() {
-                        if let Val::F64(a) = stack.pop().unwrap() {
-                            stack.push(Val::F64(a + b));
-                        }
-                    }
-                }
-                Binop::SubReal => {
-                    if let Val::F64(b) = stack.pop().unwrap() {
-                        if let Val::F64(a) = stack.pop().unwrap() {
-                            stack.push(Val::F64(a - b));
-                        }
-                    }
-                }
-                Binop::MulReal => {
-                    if let Val::F64(b) = stack.pop().unwrap() {
-                        if let Val::F64(a) = stack.pop().unwrap() {
-                            stack.push(Val::F64(a * b));
-                        }
-                    }
-                }
-                Binop::DivReal => {
-                    if let Val::F64(b) = stack.pop().unwrap() {
-                        if let Val::F64(a) = stack.pop().unwrap() {
-                            stack.push(Val::F64(a / b));
-                        }
-                    }
-                }
-            },
-            Instr::If => todo!(),
-            Instr::Else => todo!(),
-            Instr::End => todo!(),
-            Instr::For { limit: _ } => todo!(),
+fn type_of(x: &Val) -> Type {
+    match x {
+        Val::Bool(_) => Type::Bool,
+        Val::I32(_) => Type::Int,
+        Val::F64(_) => Type::Real,
+        Val::Tuple(_) => todo!(),
+        Val::Vector(_) => todo!(),
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("expected {expected} generics, got {actual}")]
+    WrongGenerics { expected: usize, actual: usize },
+
+    #[error("expected {expected} args, got {actual}")]
+    WrongArgs { expected: usize, actual: usize },
+
+    #[error("empty stack")]
+    EmptyStack,
+
+    #[error("have {num} generics, {id:?} out of range")]
+    BadGeneric { num: usize, id: Generic },
+
+    #[error("have {num} locals, {id:?} out of range")]
+    BadLocal { num: usize, id: Local },
+
+    #[error("have {num} function references, {id:?} out of range")]
+    BadFunc { num: usize, id: Func },
+
+    #[error("local {id:?} is unset")]
+    UnsetLocal { id: Local },
+
+    #[error("expected primitive type {expected:?}, got {actual:?}")]
+    ExpectedPrimitive { expected: Type, actual: Type },
+
+    #[error("expected vector, got type {actual:?}")]
+    ExpectedVector { actual: Type },
+
+    #[error("u32 {val} too big for i32")]
+    U32TooBig { val: u32 },
+
+    #[error("usize {val} too big for i32")]
+    UsizeTooBig { val: usize },
+}
+
+fn type_error(t: Type, x: &Val) -> Error {
+    Error::ExpectedPrimitive {
+        expected: t,
+        actual: type_of(x),
+    }
+}
+
+struct Interpreter<'a> {
+    f: &'a Def<Function>,
+    generics: &'a [usize],
+    locals: Vec<Option<Val>>,
+    stack: Vec<Val>,
+}
+
+impl<'a> Interpreter<'a> {
+    fn pop(&mut self) -> Result<Val, Error> {
+        self.stack.pop().ok_or(Error::EmptyStack)
+    }
+
+    fn pop_bool(&mut self) -> Result<bool, Error> {
+        match self.pop()? {
+            Val::Bool(x) => Ok(x),
+            x => Err(type_error(Type::Bool, &x)),
         }
     }
-    stack
+
+    fn pop_i32(&mut self) -> Result<i32, Error> {
+        match self.pop()? {
+            Val::I32(x) => Ok(x),
+            x => Err(type_error(Type::Int, &x)),
+        }
+    }
+
+    fn pop_f64(&mut self) -> Result<f64, Error> {
+        match self.pop()? {
+            Val::F64(x) => Ok(x),
+            x => Err(type_error(Type::Int, &x)),
+        }
+    }
+
+    fn unary_bool(&mut self, f: impl Fn(bool) -> bool) -> Result<(), Error> {
+        let a = self.pop_bool()?;
+        self.stack.push(Val::Bool(f(a)));
+        Ok(())
+    }
+
+    fn unary_i32(&mut self, f: impl Fn(i32) -> i32) -> Result<(), Error> {
+        let a = self.pop_i32()?;
+        self.stack.push(Val::I32(f(a)));
+        Ok(())
+    }
+
+    fn unary_f64(&mut self, f: impl Fn(f64) -> f64) -> Result<(), Error> {
+        let a = self.pop_f64()?;
+        self.stack.push(Val::F64(f(a)));
+        Ok(())
+    }
+
+    fn fold_i32(&mut self, init: i32, f: impl Fn(i32, i32) -> i32) -> Result<(), Error> {
+        match self.pop()? {
+            Val::Vector(v) => {
+                let mut acc = init;
+                for val in v {
+                    match val.as_ref() {
+                        Val::I32(x) => acc = f(acc, *x),
+                        x => return Err(type_error(Type::Int, x)),
+                    }
+                }
+                Ok(())
+            }
+            x => Err(Error::ExpectedVector {
+                actual: type_of(&x),
+            }),
+        }
+    }
+
+    fn fold_f64(&mut self, init: f64, f: impl Fn(f64, f64) -> f64) -> Result<(), Error> {
+        match self.pop()? {
+            Val::Vector(v) => {
+                let mut acc = init;
+                for val in v {
+                    match val.as_ref() {
+                        Val::F64(x) => acc = f(acc, *x),
+                        x => return Err(type_error(Type::Real, x)),
+                    }
+                }
+                Ok(())
+            }
+            x => Err(Error::ExpectedVector {
+                actual: type_of(&x),
+            }),
+        }
+    }
+
+    fn unary(&mut self, op: Unop) -> Result<(), Error> {
+        use Unop::*;
+        match op {
+            Not => self.unary_bool(|a| !a),
+            NegInt => self.unary_i32(|a| -a),
+            AbsInt => self.unary_i32(|a| a.abs()),
+            NegReal => self.unary_f64(|a| -a),
+            AbsReal => self.unary_f64(|a| a.abs()),
+            Sqrt => self.unary_f64(|a| a.sqrt()),
+            SumInt => self.fold_i32(0, |a, b| a + b),
+            ProdInt => self.fold_i32(1, |a, b| a * b),
+            MaxInt => self.fold_i32(i32::MIN, |a, b| a.max(b)),
+            MinInt => self.fold_i32(i32::MAX, |a, b| a.min(b)),
+            SumReal => self.fold_f64(0., |a, b| a + b),
+            ProdReal => self.fold_f64(1., |a, b| a * b),
+            MaxReal => self.fold_f64(f64::NEG_INFINITY, |a, b| a.max(b)),
+            MinReal => self.fold_f64(f64::INFINITY, |a, b| a.min(b)),
+        }
+    }
+
+    fn logic(&mut self, f: impl Fn(bool, bool) -> bool) -> Result<(), Error> {
+        let b = self.pop_bool()?;
+        let a = self.pop_bool()?;
+        self.stack.push(Val::Bool(f(a, b)));
+        Ok(())
+    }
+
+    fn comp_i32(&mut self, f: impl Fn(i32, i32) -> bool) -> Result<(), Error> {
+        let b = self.pop_i32()?;
+        let a = self.pop_i32()?;
+        self.stack.push(Val::Bool(f(a, b)));
+        Ok(())
+    }
+
+    fn comp_f64(&mut self, f: impl Fn(f64, f64) -> bool) -> Result<(), Error> {
+        let b = self.pop_f64()?;
+        let a = self.pop_f64()?;
+        self.stack.push(Val::Bool(f(a, b)));
+        Ok(())
+    }
+
+    fn bin_i32(&mut self, f: impl Fn(i32, i32) -> i32) -> Result<(), Error> {
+        let b = self.pop_i32()?;
+        let a = self.pop_i32()?;
+        self.stack.push(Val::I32(f(a, b)));
+        Ok(())
+    }
+
+    fn bin_f64(&mut self, f: impl Fn(f64, f64) -> f64) -> Result<(), Error> {
+        let b = self.pop_f64()?;
+        let a = self.pop_f64()?;
+        self.stack.push(Val::F64(f(a, b)));
+        Ok(())
+    }
+
+    fn binary(&mut self, op: Binop) -> Result<(), Error> {
+        use Binop::*;
+        match op {
+            And => self.logic(|a, b| a && b),
+            Or => self.logic(|a, b| a || b),
+            EqBool => self.logic(|a, b| a == b),
+            NeqBool => self.logic(|a, b| a != b),
+            NeqInt => self.comp_i32(|a, b| a != b),
+            LtInt => self.comp_i32(|a, b| a < b),
+            LeqInt => self.comp_i32(|a, b| a <= b),
+            EqInt => self.comp_i32(|a, b| a == b),
+            GtInt => self.comp_i32(|a, b| a > b),
+            GeqInt => self.comp_i32(|a, b| a >= b),
+            NeqReal => self.comp_f64(|a, b| a != b),
+            LtReal => self.comp_f64(|a, b| a < b),
+            LeqReal => self.comp_f64(|a, b| a <= b),
+            EqReal => self.comp_f64(|a, b| a == b),
+            GtReal => self.comp_f64(|a, b| a > b),
+            GeqReal => self.comp_f64(|a, b| a >= b),
+            AddInt => self.bin_i32(|a, b| a + b), // TODO: handle overflow
+            SubInt => self.bin_i32(|a, b| a - b),
+            MulInt => self.bin_i32(|a, b| a * b),
+            DivInt => self.bin_i32(|a, b| a / b),
+            Mod => self.bin_i32(|a, b| a % b),
+            AddReal => self.bin_f64(|a, b| a + b),
+            SubReal => self.bin_f64(|a, b| a - b),
+            MulReal => self.bin_f64(|a, b| a * b),
+            DivReal => self.bin_f64(|a, b| a / b),
+        }
+    }
+
+    fn get_generic(&self, id: Generic) -> Result<usize, Error> {
+        self.generics.get(id.0).copied().ok_or(Error::BadGeneric {
+            num: self.f.generics,
+            id,
+        })
+    }
+
+    fn instr(&mut self, instr: Instr) -> Result<(), Error> {
+        use Instr::*;
+        match instr {
+            Generic { id } => {
+                let val = self.get_generic(id)?;
+                self.stack.push(Val::I32(
+                    val.try_into().map_err(|_| Error::UsizeTooBig { val })?,
+                ));
+                Ok(())
+            }
+            Get { id } => {
+                let val = self.locals.get(id.0).ok_or(Error::BadLocal {
+                    num: self.f.def.locals.len(),
+                    id,
+                })?;
+                self.stack
+                    .push(val.as_ref().ok_or(Error::UnsetLocal { id })?.clone());
+                Ok(())
+            }
+            Set { id } => {
+                let val = self.pop()?;
+                let local = self.locals.get_mut(id.0).ok_or(Error::BadLocal {
+                    num: self.f.def.locals.len(),
+                    id,
+                })?;
+                *local = Some(val);
+                Ok(())
+            }
+            Bool { val } => {
+                self.stack.push(Val::Bool(val));
+                Ok(())
+            }
+            Int { val } => {
+                self.stack.push(Val::I32(
+                    val.try_into().map_err(|_| Error::U32TooBig { val })?,
+                ));
+                Ok(())
+            }
+            Real { val } => {
+                self.stack.push(Val::F64(val));
+                Ok(())
+            }
+            Vector { id: _ } => todo!(),
+            Tuple { id: _ } => todo!(),
+            Index => todo!(),
+            Member { id: _ } => todo!(),
+            Call { id } => {
+                let func = self.f.def.funcs.get(id.0).ok_or(Error::BadFunc {
+                    num: self.f.def.funcs.len(),
+                    id,
+                })?;
+                let generics: Result<Vec<usize>, Error> = func
+                    .params
+                    .iter()
+                    .map(|&size| match size {
+                        Size::Const { val } => Ok(val),
+                        Size::Generic { id } => self.get_generic(id),
+                    })
+                    .collect();
+                let g = func.def.as_ref();
+                let args = self
+                    .stack
+                    .drain(self.stack.len() - g.def.params.len()..) // TODO: don't panic
+                    .collect();
+                self.stack.append(&mut interp(g, &generics?, args)?);
+                Ok(())
+            }
+            Unary { op } => self.unary(op),
+            Binary { op } => self.binary(op),
+            If => todo!(),
+            Else => todo!(),
+            End => todo!(),
+            For { limit: _ } => todo!(),
+        }
+    }
+}
+
+// TODO: return a stack trace with instruction indices, instead of just the error kind
+pub fn interp(f: &Def<Function>, generics: &[usize], args: Vec<Val>) -> Result<Vec<Val>, Error> {
+    if generics.len() != f.generics {
+        return Err(Error::WrongGenerics {
+            expected: f.generics,
+            actual: generics.len(),
+        });
+    }
+    if args.len() != f.def.params.len() {
+        return Err(Error::WrongArgs {
+            expected: f.def.params.len(),
+            actual: args.len(),
+        });
+    }
+    let mut interpreter = Interpreter {
+        f,
+        generics,
+        locals: vec![None; f.def.locals.len()],
+        stack: args,
+    };
+    for &instr in &f.def.body {
+        interpreter.instr(instr)?;
+    }
+    Ok(interpreter.stack)
 }
 
 #[cfg(test)]
@@ -123,7 +372,7 @@ mod tests {
                 body: vec![Instr::Binary { op: Binop::AddReal }],
             },
         };
-        let answer = interp(&f, vec![Val::F64(2.), Val::F64(2.)]);
+        let answer = interp(&f, &[], vec![Val::F64(2.), Val::F64(2.)]).unwrap();
         assert_eq!(answer, vec![Val::F64(4.)]);
     }
 
@@ -160,7 +409,7 @@ mod tests {
                 ],
             },
         };
-        let answer = interp(&g, vec![]);
+        let answer = interp(&g, &[], vec![]).unwrap();
         assert_eq!(answer, vec![Val::F64(1764.)]);
     }
 }

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -451,9 +451,9 @@ impl Context {
 /// The `args` are each Serde-converted to `Vec<rose_interp::Val>`, and the return value is
 /// Serde-converted from `rose_interp::Val`.
 #[wasm_bindgen]
-pub fn interp(Func(f): &Func, generics: Vec<usize>, args: JsValue) -> Result<JsValue, JsError> {
+pub fn interp(Func(f): &Func, generics: &[usize], args: JsValue) -> Result<JsValue, JsError> {
     let vals: Vec<rose_interp::Val> = serde_wasm_bindgen::from_value(args)?;
-    let ret = rose_interp::interp(f, &generics, vals)?;
+    let ret = rose_interp::interp(f, generics, vals)?;
     assert_eq!(ret.len(), 1);
     Ok(to_js_value(&ret[0])?)
 }

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 use std::rc::Rc;
-use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
+use wasm_bindgen::prelude::{wasm_bindgen, JsError, JsValue};
 
 #[wasm_bindgen]
 pub fn initialize() {
@@ -52,10 +52,7 @@ impl Context {
     /// - non-primitive types
     /// - calling other functions
     #[wasm_bindgen(constructor)]
-    pub fn new(
-        param_types: JsValue,
-        ret_type: JsValue,
-    ) -> Result<Context, serde_wasm_bindgen::Error> {
+    pub fn new(param_types: JsValue, ret_type: JsValue) -> Result<Context, JsError> {
         let params: Vec<rose::Type> = serde_wasm_bindgen::from_value(param_types)?;
         let ret: rose::Type = serde_wasm_bindgen::from_value(ret_type)?;
         Ok(Self {
@@ -73,7 +70,7 @@ impl Context {
     ///
     /// The `t` argument is Serde-converted to `rose::Type`.
     #[wasm_bindgen]
-    pub fn set(&mut self, t: JsValue) -> Result<usize, serde_wasm_bindgen::Error> {
+    pub fn set(&mut self, t: JsValue) -> Result<usize, JsError> {
         let local: rose::Type = serde_wasm_bindgen::from_value(t)?;
         let id = self.locals.len();
         self.locals.push(local);
@@ -454,9 +451,9 @@ impl Context {
 /// The `args` are each Serde-converted to `Vec<rose_interp::Val>`, and the return value is
 /// Serde-converted from `rose_interp::Val`.
 #[wasm_bindgen]
-pub fn interp(Func(f): &Func, args: JsValue) -> Result<JsValue, serde_wasm_bindgen::Error> {
+pub fn interp(Func(f): &Func, generics: Vec<usize>, args: JsValue) -> Result<JsValue, JsError> {
     let vals: Vec<rose_interp::Val> = serde_wasm_bindgen::from_value(args)?;
-    let ret = rose_interp::interp(f, vals);
+    let ret = rose_interp::interp(f, &generics, vals)?;
     assert_eq!(ret.len(), 1);
-    to_js_value(&ret[0])
+    Ok(to_js_value(&ret[0])?)
 }

--- a/packages/core/src/ffi.ts
+++ b/packages/core/src/ffi.ts
@@ -50,6 +50,7 @@ export const bake = (ctx: Context): Fn => {
   return fn;
 };
 
-export const interp = (f: Fn, args: Val[]): Val => wasm.interp(f.f, args);
+export const interp = (f: Fn, args: Val[]): Val =>
+  wasm.interp(f.f, new Uint32Array(), args); // TODO: support generics
 
 export type { Type, Val };


### PR DESCRIPTION
Resolves #27, plus adding much better error handling. Obviously more work remains, so I'll open followup issues for those after this PR is merged.

I swapped `Val::Tuple` and `Val::Vector` from `Vec<Rc<Val>>` to `Rc<Vec<Val>>` because I realized it's more efficient.

I went and replaced a few of our error types in `rose-web` with [`JsError`](https://docs.rs/wasm-bindgen/0.2.84/wasm_bindgen/struct.JsError.html) because this PR adds a new `Error` type to `rose-interp`, and `JsError` is the nicest common denominator to convert everything into.