### PR TITLE
Print Rust IR from a `rose` function

### DIFF
--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -42,6 +42,14 @@ pub fn bake(ctx: Context) -> Func {
     }))
 }
 
+// Debugging
+#[wasm_bindgen(js_name = "js2Rust")]
+pub fn js_to_rust(Func(f): &Func) -> String {
+    let def: &rose::Def<rose::Function> = f;
+    let func: &rose::Function = &def.def;
+    format!("{:#?}", func)
+}
+
 #[wasm_bindgen]
 impl Context {
     /// The `param_types` argument is Serde-converted to `Vec<rose::Type>`, and the `ret_type`

--- a/packages/core/src/debug.test.ts
+++ b/packages/core/src/debug.test.ts
@@ -1,0 +1,77 @@
+import * as wasm from "@rose-lang/wasm";
+import { expect, test } from "vitest";
+import { Real, add, fn, mul } from "./index.js";
+
+test("test rose to rust formatting", () => {
+  const f = fn([Real, Real], (x, y) => add(mul(x, 2), y));
+  const g = wasm.js2Rust(f.f.f);
+  expect(g).toBe(
+    `Function {
+    params: [
+        Real,
+        Real,
+    ],
+    ret: [
+        Real,
+    ],
+    locals: [
+        Real,
+        Real,
+        Real,
+        Real,
+    ],
+    funcs: [],
+    body: [
+        Set {
+            id: Local(
+                0,
+            ),
+        },
+        Set {
+            id: Local(
+                1,
+            ),
+        },
+        Get {
+            id: Local(
+                1,
+            ),
+        },
+        Real {
+            val: 2.0,
+        },
+        Binary {
+            op: MulReal,
+        },
+        Set {
+            id: Local(
+                2,
+            ),
+        },
+        Get {
+            id: Local(
+                2,
+            ),
+        },
+        Get {
+            id: Local(
+                0,
+            ),
+        },
+        Binary {
+            op: AddReal,
+        },
+        Set {
+            id: Local(
+                3,
+            ),
+        },
+        Get {
+            id: Local(
+                3,
+            ),
+        },
+    ],
+}`
+  );
+});

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -1,4 +1,3 @@
-import * as wasm from "@rose-lang/wasm";
 import { expect, test } from "vitest";
 import { Real, add, div, fn, interp, mul, sub } from "./index.js";
 
@@ -13,8 +12,3 @@ test("basic arithmetic", () => {
   const g = interp(f);
   expect(g()).toBe(6);
 });
-
-// Printing a js fuction's rust IR to console
-const f = fn([Real, Real], (x, y) => add(x, y));
-const g = wasm.js2Rust(f.f.f);
-console.log(g);

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -1,3 +1,4 @@
+import * as wasm from "@rose-lang/wasm";
 import { expect, test } from "vitest";
 import { Real, add, div, fn, interp, mul, sub } from "./index.js";
 
@@ -12,3 +13,8 @@ test("basic arithmetic", () => {
   const g = interp(f);
   expect(g()).toBe(6);
 });
+
+// Printing a js fuction's rust IR to console
+const f = fn([Real, Real], (x, y) => add(x, y));
+const g = wasm.js2Rust(f.f.f);
+console.log(g);


### PR DESCRIPTION
This is a tiny PR that implements the `js2Rust` function, and exports it from the `web` crate. We can now take a `rose` function defined in JS-land and print its Rust IR which is helpful for debugging. 