### PR TITLE
Put core IR ID types into their own module

### DIFF
--- a/crates/core/src/id.rs
+++ b/crates/core/src/id.rs
@@ -1,0 +1,85 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[cfg(test)]
+use ts_rs::TS;
+
+/// Index of a typevar in a definition context.
+#[cfg_attr(test, derive(TS), ts(export))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug)]
+pub struct Typ(usize);
+
+pub fn typ(id: usize) -> Typ {
+    Typ(id)
+}
+
+impl Typ {
+    pub fn typ(self) -> usize {
+        self.0
+    }
+}
+
+/// Index of a function instantiation in a definition context.
+#[cfg_attr(test, derive(TS), ts(export))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug)]
+pub struct Func(usize);
+
+pub fn func(id: usize) -> Func {
+    Func(id)
+}
+
+impl Func {
+    pub fn func(self) -> usize {
+        self.0
+    }
+}
+
+/// Index of a generic parameter in a definition context.
+#[cfg_attr(test, derive(TS), ts(export))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug)]
+pub struct Generic(usize);
+
+pub fn generic(id: usize) -> Generic {
+    Generic(id)
+}
+
+impl Generic {
+    pub fn generic(self) -> usize {
+        self.0
+    }
+}
+
+/// Index of a member in a tuple.
+#[cfg_attr(test, derive(TS), ts(export))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug)]
+pub struct Member(usize);
+
+pub fn member(id: usize) -> Member {
+    Member(id)
+}
+
+impl Member {
+    pub fn member(self) -> usize {
+        self.0
+    }
+}
+
+/// Index of a local variable in a function context.
+#[cfg_attr(test, derive(TS), ts(export))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug)]
+pub struct Local(usize);
+
+pub fn local(id: usize) -> Local {
+    Local(id)
+}
+
+impl Local {
+    pub fn local(self) -> usize {
+        self.0
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod id;
+
 use std::rc::Rc;
 
 #[cfg(feature = "serde")]
@@ -6,42 +8,12 @@ use serde::{Deserialize, Serialize};
 #[cfg(test)]
 use ts_rs::TS;
 
-/// Index of a typevar in a definition context.
-#[cfg_attr(test, derive(TS), ts(export))]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Clone, Copy, Debug)]
-pub struct Var(pub usize);
-
-/// Index of a function instantiation in a definition context.
-#[cfg_attr(test, derive(TS), ts(export))]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Clone, Copy, Debug)]
-pub struct Func(pub usize);
-
-/// Index of a generic parameter in a definition context.
-#[cfg_attr(test, derive(TS), ts(export))]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Clone, Copy, Debug)]
-pub struct Generic(pub usize);
-
-/// Index of a member in a tuple.
-#[cfg_attr(test, derive(TS), ts(export))]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Clone, Copy, Debug)]
-pub struct Member(pub usize);
-
-/// Index of a local variable in a function context.
-#[cfg_attr(test, derive(TS), ts(export))]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Clone, Copy, Debug)]
-pub struct Local(pub usize);
-
 #[cfg_attr(test, derive(TS), ts(export))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, Debug)]
 pub enum Size {
     Const { val: usize },
-    Generic { id: Generic },
+    Generic { id: id::Generic },
 }
 
 #[cfg_attr(test, derive(TS), ts(export))]
@@ -53,7 +25,7 @@ pub enum Type {
     Real,
     Size { val: Size },
     Nat { bound: Size },
-    Var { id: Var },
+    Var { id: id::Typ },
 }
 
 #[derive(Debug)]
@@ -159,17 +131,17 @@ pub enum Binop {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, Debug)]
 pub enum Instr {
-    Generic { id: Generic },
-    Get { id: Local },
-    Set { id: Local },
+    Generic { id: id::Generic },
+    Get { id: id::Local },
+    Set { id: id::Local },
     Bool { val: bool },
     Int { val: u32 },
     Real { val: f64 },
-    Vector { id: Var },
-    Tuple { id: Var },
+    Vector { id: id::Typ },
+    Tuple { id: id::Typ },
     Index,
-    Member { id: Member },
-    Call { id: Func },
+    Member { id: id::Member },
+    Call { id: id::Func },
     Unary { op: Unop },
     Binary { op: Binop },
     If,

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -1,3 +1,4 @@
+use rose::id;
 use serde::Serialize;
 use std::rc::Rc;
 use wasm_bindgen::prelude::{wasm_bindgen, JsError, JsValue};
@@ -84,24 +85,20 @@ impl Context {
         let local: rose::Type = serde_wasm_bindgen::from_value(t)?;
         let id = self.locals.len();
         self.locals.push(local);
-        self.body.push(rose::Instr::Set {
-            id: rose::Local(id),
-        });
+        self.body.push(rose::Instr::Set { id: id::local(id) });
         Ok(id)
     }
 
     #[wasm_bindgen]
     pub fn generic(&mut self, id: usize) {
         self.body.push(rose::Instr::Generic {
-            id: rose::Generic(id),
+            id: id::generic(id),
         });
     }
 
     #[wasm_bindgen]
     pub fn get(&mut self, id: usize) {
-        self.body.push(rose::Instr::Get {
-            id: rose::Local(id),
-        });
+        self.body.push(rose::Instr::Get { id: id::local(id) });
     }
 
     #[wasm_bindgen]
@@ -121,12 +118,12 @@ impl Context {
 
     #[wasm_bindgen]
     pub fn vector(&mut self, id: usize) {
-        self.body.push(rose::Instr::Vector { id: rose::Var(id) });
+        self.body.push(rose::Instr::Vector { id: id::typ(id) });
     }
 
     #[wasm_bindgen]
     pub fn tuple(&mut self, id: usize) {
-        self.body.push(rose::Instr::Tuple { id: rose::Var(id) });
+        self.body.push(rose::Instr::Tuple { id: id::typ(id) });
     }
 
     #[wasm_bindgen]
@@ -136,9 +133,7 @@ impl Context {
 
     #[wasm_bindgen]
     pub fn member(&mut self, id: usize) {
-        self.body.push(rose::Instr::Member {
-            id: rose::Member(id),
-        });
+        self.body.push(rose::Instr::Member { id: id::member(id) });
     }
 
     // unary
@@ -450,7 +445,7 @@ impl Context {
     pub fn for_generic(&mut self, id: usize) {
         self.body.push(rose::Instr::For {
             limit: rose::Size::Generic {
-                id: rose::Generic(id),
+                id: id::generic(id),
             },
         });
     }


### PR DESCRIPTION
Several of our core IR types are just wrappers around `usize`, which we use instead of plain `usize` in order to make it clearer in code what each ID represents, and prevent refactoring errors since a lot of our variable names for these are just `id`. However, these types have a couple problems:

1. Their names are often very similar to those of other core IR types, leading to many confusing distinctions (e.g. we've just using just `Var` for the "type var ID" type).
2. When we need to convert one of these ID types to a `usize` to index into a vector, the only ways to do it are destructuring (which introduces a local variable of plain `usize` type) and using the `.0` syntax (which would look the same on any ID type, not great for preventing refactoring errors).

This PR solves these problems by moving all those ID types into a new `rose::id` module and making their inner `usize` private, instead forcing users to create and consume them by functions and methods which are just lowercased versions of their respective ID type names. Also, `Var` is now `Typ`.