### PR TITLE
Run Vitest with `--no-threads`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ core: yarn wasm
 
 # test
 test-core: yarn wasm
-	yarn workspace rose test run
+	yarn workspace rose test run --no-threads
 
 ## `packages/site`
 


### PR DESCRIPTION
Vitest has occasionally been hanging for me, so this PR attempts to fix that problem by passing [`--no-threads`](https://vitest.dev/guide/features.html#threads), similar to https://github.com/penrose/penrose/pull/1440.