### PR TITLE
Have just one kind of type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,6 +377,7 @@ checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.0",
+ "serde",
 ]
 
 [[package]]
@@ -673,6 +674,7 @@ version = "0.0.0"
 dependencies = [
  "console_error_panic_hook",
  "enumset",
+ "indexmap 2.0.0",
  "rose",
  "rose-interp",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,6 +280,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88bffebc5d80432c9b140ee17875ff173a8ab62faad5b257da912bd2f6c1c0a1"
+
+[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -330,6 +336,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,7 +366,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.0",
 ]
 
 [[package]]
@@ -531,7 +553,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
 dependencies = [
  "fixedbitset",
- "indexmap",
+ "indexmap 1.9.3",
 ]
 
 [[package]]
@@ -625,6 +647,7 @@ name = "rose-frontend"
 version = "0.0.0"
 dependencies = [
  "enumset",
+ "indexmap 2.0.0",
  "lalrpop",
  "lalrpop-util",
  "logos",
@@ -637,6 +660,7 @@ dependencies = [
 name = "rose-interp"
 version = "0.0.0"
 dependencies = [
+ "indexmap 2.0.0",
  "rose",
  "serde",
  "thiserror",

--- a/crates/core/src/id.rs
+++ b/crates/core/src/id.rs
@@ -71,7 +71,7 @@ impl Generic {
 #[cfg_attr(
     feature = "serde",
     derive(Serialize, Deserialize),
-    serde(rename = "TypexprId")
+    serde(rename = "TyId")
 )]
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Ty(usize);

--- a/crates/core/src/id.rs
+++ b/crates/core/src/id.rs
@@ -13,7 +13,7 @@ use ts_rs::TS;
     derive(Serialize, Deserialize),
     serde(rename = "MemberId")
 )]
-#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Member(usize);
 
 pub fn member(id: usize) -> Member {
@@ -26,26 +26,6 @@ impl Member {
     }
 }
 
-/// Index of a typedef in a definition context.
-#[cfg_attr(test, derive(TS), ts(export))]
-#[cfg_attr(
-    feature = "serde",
-    derive(Serialize, Deserialize),
-    serde(rename = "TypedefId")
-)]
-#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct Typedef(usize);
-
-pub fn typedef(id: usize) -> Typedef {
-    Typedef(id)
-}
-
-impl Typedef {
-    pub fn typedef(self) -> usize {
-        self.0
-    }
-}
-
 /// Index of an uninstantiated function reference in a definition context.
 #[cfg_attr(test, derive(TS), ts(export))]
 #[cfg_attr(
@@ -53,7 +33,7 @@ impl Typedef {
     derive(Serialize, Deserialize),
     serde(rename = "FunctionId")
 )]
-#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Function(usize);
 
 pub fn function(id: usize) -> Function {
@@ -73,7 +53,7 @@ impl Function {
     derive(Serialize, Deserialize),
     serde(rename = "GenericId")
 )]
-#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Generic(usize);
 
 pub fn generic(id: usize) -> Generic {
@@ -86,22 +66,22 @@ impl Generic {
     }
 }
 
-/// Index of a typexpr in a definition context.
+/// Index of a type in a definition context.
 #[cfg_attr(test, derive(TS), ts(export))]
 #[cfg_attr(
     feature = "serde",
     derive(Serialize, Deserialize),
     serde(rename = "TypexprId")
 )]
-#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct Typexpr(usize);
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct Ty(usize);
 
-pub fn typexpr(id: usize) -> Typexpr {
-    Typexpr(id)
+pub fn ty(id: usize) -> Ty {
+    Ty(id)
 }
 
-impl Typexpr {
-    pub fn typexpr(self) -> usize {
+impl Ty {
+    pub fn ty(self) -> usize {
         self.0
     }
 }
@@ -113,7 +93,7 @@ impl Typexpr {
     derive(Serialize, Deserialize),
     serde(rename = "FuncId")
 )]
-#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Func(usize);
 
 pub fn func(id: usize) -> Func {
@@ -133,7 +113,7 @@ impl Func {
     derive(Serialize, Deserialize),
     serde(rename = "VarId")
 )]
-#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Var(usize);
 
 pub fn var(id: usize) -> Var {
@@ -153,7 +133,7 @@ impl Var {
     derive(Serialize, Deserialize),
     serde(rename = "BlockId")
 )]
-#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Block(usize);
 
 pub fn block(id: usize) -> Block {

--- a/crates/frontend/Cargo.toml
+++ b/crates/frontend/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 
 [dependencies]
 enumset = "1"
+indexmap = "2"
 lalrpop-util = "0.19"
 logos = "0.13"
 rose = { path = "../core" }

--- a/crates/frontend/src/translate.rs
+++ b/crates/frontend/src/translate.rs
@@ -58,7 +58,7 @@ fn parse_types<'input>(
     let mut generics = HashMap::new();
     let mut params = vec![];
     for typ in typenames {
-        params.push(if let Some(_) = lookup(typ.val) {
+        params.push(if lookup(typ.val).is_some() {
             todo!()
         } else {
             let (real, _) = types.insert_full(ir::Ty::F64);

--- a/crates/frontend/src/translate.rs
+++ b/crates/frontend/src/translate.rs
@@ -1,5 +1,6 @@
 use crate::{ast, tokens};
 use enumset::EnumSet;
+use indexmap::{IndexMap, IndexSet};
 use rose::{self as ir, id};
 use std::{collections::HashMap, ops::Range};
 
@@ -21,7 +22,7 @@ pub enum TypeError {
     UnknownFunc { name: Range<usize> },
 
     #[error("")]
-    IndexPrimitive { t: ir::Type },
+    IndexPrimitive { t: ir::Ty },
 
     #[error("")]
     IndexRef,
@@ -30,7 +31,7 @@ pub enum TypeError {
     IndexTuple,
 
     #[error("")]
-    MemberPrimitive { t: ir::Type },
+    MemberPrimitive { t: ir::Ty },
 
     #[error("")]
     MemberRef,
@@ -44,97 +45,72 @@ pub enum TypeError {
     #[error("")]
     BadBinaryArgs {
         op: tokens::Binop,
-        left: ir::Type,
-        right: ir::Type,
+        left: ir::Ty,
+        right: ir::Ty,
     },
 }
 
-type ParsedTypes<'input> = (
-    HashMap<&'input str, id::Generic>,
-    Vec<ir::Typexpr>,
-    Vec<ir::Type>,
-);
-
 fn parse_types<'input>(
-    lookup: impl Fn(&'input str) -> Option<id::Typedef>,
+    lookup: impl Fn(&'input str) -> Option<&Typedef>,
+    types: &mut IndexSet<ir::Ty>,
     typenames: impl Iterator<Item = ast::Spanned<&'input str>>,
-) -> Result<ParsedTypes<'input>, TypeError> {
+) -> Result<(HashMap<&'input str, id::Generic>, Vec<id::Ty>), TypeError> {
     let mut generics = HashMap::new();
-    let mut typevars = vec![];
-    let mut types = vec![];
+    let mut params = vec![];
     for typ in typenames {
-        types.push(if let Some(id) = lookup(typ.val) {
-            let typexpr = ir::Typexpr::Def { id, params: vec![] };
-            let id = id::typexpr(typevars.len());
-            typevars.push(typexpr);
-            ir::Type::Expr { id }
+        params.push(if let Some(_) = lookup(typ.val) {
+            todo!()
         } else {
-            let mut t = ir::Type::F64;
+            let (real, _) = types.insert_full(ir::Ty::F64);
+            let mut t = id::ty(real);
             let dims = typ
                 .val
                 .strip_prefix('R')
                 .ok_or_else(|| TypeError::UnknownType { name: typ.span() })?;
             if !dims.is_empty() {
                 for dim in dims.rsplit('x') {
-                    let typexpr = ir::Typexpr::Array {
-                        elem: t,
-                        index: if let Ok(n) = dim.parse() {
-                            ir::Type::Fin { size: n }
-                        } else if dim.is_empty() {
-                            // TODO: change this condition to check for valid identifiers
-                            return Err(TypeError::BadTensorType { name: typ.span() });
-                        } else {
-                            ir::Type::Generic {
-                                id: if let Some(&i) = generics.get(dim) {
-                                    i
-                                } else {
-                                    let i = id::generic(generics.len());
-                                    generics.insert(dim, i);
-                                    i
-                                },
-                            }
-                        },
+                    let index = if let Ok(n) = dim.parse() {
+                        ir::Ty::Fin { size: n }
+                    } else if dim.is_empty() {
+                        // TODO: change this condition to check for valid identifiers
+                        return Err(TypeError::BadTensorType { name: typ.span() });
+                    } else {
+                        ir::Ty::Generic {
+                            id: if let Some(&i) = generics.get(dim) {
+                                i
+                            } else {
+                                let i = id::generic(generics.len());
+                                generics.insert(dim, i);
+                                i
+                            },
+                        }
                     };
-                    let id = id::typexpr(typevars.len());
-                    typevars.push(typexpr);
-                    t = ir::Type::Expr { id };
+                    let (i, _) = types.insert_full(index);
+                    let typexpr = ir::Ty::Array {
+                        elem: t,
+                        index: id::ty(i),
+                    };
+                    let (id, _) = types.insert_full(typexpr);
+                    t = id::ty(id);
                 }
             }
             t
         });
     }
-    Ok((generics, typevars, types))
+    Ok((generics, params))
 }
 
 #[derive(Debug)]
-pub struct Type<'input> {
-    pub def: rose::Typedef,
+pub struct Typedef<'input> {
+    pub types: Vec<ir::Ty>,
     /// Sorted lexicographically.
-    pub fields: Vec<&'input str>,
+    pub fields: IndexMap<&'input str, id::Ty>,
 }
 
 #[derive(Debug)]
 pub struct Module<'input> {
-    types: Vec<Type<'input>>,
-    funcs: Vec<rose::Function>,
-    typenames: HashMap<&'input str, id::Typedef>,
-    funcnames: HashMap<&'input str, id::Function>,
-}
-
-#[derive(Clone, Copy, Debug)]
-pub struct TypeRef<'input, 'a> {
-    m: &'a Module<'input>,
-    id: id::Typedef,
-}
-
-impl rose::TypeNode for TypeRef<'_, '_> {
-    fn def(&self) -> &rose::Typedef {
-        &self.m.types[self.id.typedef()].def
-    }
-
-    fn ty(&self, _id: id::Typedef) -> Option<Self> {
-        None
-    }
+    types: IndexMap<&'input str, Typedef<'input>>,
+    funcs: IndexMap<&'input str, rose::Function>,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -144,30 +120,26 @@ pub struct FuncRef<'input, 'a> {
 }
 
 impl<'input, 'a> rose::FuncNode for FuncRef<'input, 'a> {
-    type Ty = TypeRef<'input, 'a>;
-
     fn def(&self) -> &rose::Function {
         &self.m.funcs[self.id.function()]
     }
 
-    fn ty(&self, id: id::Typedef) -> Option<Self::Ty> {
-        Some(TypeRef { m: self.m, id })
-    }
-
-    fn func(&self, id: id::Function) -> Option<Self> {
+    fn get(&self, id: id::Function) -> Option<Self> {
         Some(Self { m: self.m, id })
     }
 }
 
 impl Module<'_> {
-    pub fn get_type(&self, name: &str) -> Option<TypeRef> {
-        let &id = self.typenames.get(name)?;
-        Some(TypeRef { m: self, id })
+    pub fn get_type(&self, name: &str) -> Option<&Typedef> {
+        self.types.get(name)
     }
 
     pub fn get_func(&self, name: &str) -> Option<FuncRef> {
-        let &id = self.funcnames.get(name)?;
-        Some(FuncRef { m: self, id })
+        let i = self.funcs.get_index_of(name)?;
+        Some(FuncRef {
+            m: self,
+            id: id::function(i),
+        })
     }
 }
 
@@ -175,21 +147,20 @@ struct BlockCtx<'input, 'a> {
     m: &'a Module<'input>,
     g: HashMap<&'input str, id::Generic>,
     l: HashMap<&'input str, id::Var>,
-    t: Vec<ir::Typexpr>,
+    t: IndexSet<ir::Ty>,
     f: Vec<ir::Func>,
-    v: Vec<ir::Type>,
+    v: Vec<id::Ty>,
     b: Vec<ir::Block>,
     c: Vec<ir::Instr>,
 }
 
 impl<'input, 'a> BlockCtx<'input, 'a> {
-    fn newtype(&mut self, t: ir::Typexpr) -> id::Typexpr {
-        let id = id::typexpr(self.t.len());
-        self.t.push(t);
-        id
+    fn newtype(&mut self, t: ir::Ty) -> id::Ty {
+        let (i, _) = self.t.insert_full(t);
+        id::ty(i)
     }
 
-    fn newlocal(&mut self, t: ir::Type) -> id::Var {
+    fn newlocal(&mut self, t: id::Ty) -> id::Var {
         let id = id::var(self.v.len());
         self.v.push(t);
         id
@@ -201,15 +172,15 @@ impl<'input, 'a> BlockCtx<'input, 'a> {
         id
     }
 
-    fn gettype(&self, id: id::Typexpr) -> &ir::Typexpr {
-        &self.t[id.typexpr()]
+    fn gettype(&self, id: id::Ty) -> &ir::Ty {
+        &self.t[id.ty()]
     }
 
-    fn getlocal(&self, id: id::Var) -> ir::Type {
+    fn getlocal(&self, id: id::Var) -> id::Ty {
         self.v[id.var()]
     }
 
-    fn instr(&mut self, t: ir::Type, expr: ir::Expr) -> id::Var {
+    fn instr(&mut self, t: id::Ty, expr: ir::Expr) -> id::Var {
         let var = self.newlocal(t);
         self.c.push(ir::Instr { var, expr });
         var
@@ -228,8 +199,8 @@ impl<'input, 'a> BlockCtx<'input, 'a> {
     fn unify(
         &mut self,
         _f: &ir::Function,
-        _args: &[ir::Type],
-    ) -> Result<(Vec<ir::Type>, ir::Type), TypeError> {
+        _args: &[id::Ty],
+    ) -> Result<(Vec<id::Ty>, id::Ty), TypeError> {
         todo!()
     }
 
@@ -249,11 +220,12 @@ impl<'input, 'a> BlockCtx<'input, 'a> {
                     .collect::<Result<Vec<id::Var>, TypeError>>()?;
                 match vars.first() {
                     Some(&x) => {
-                        let t = self.newtype(ir::Typexpr::Array {
-                            index: ir::Type::Fin { size: vars.len() },
+                        let index = self.newtype(ir::Ty::Fin { size: vars.len() });
+                        let ty = self.newtype(ir::Ty::Array {
+                            index,
                             elem: self.getlocal(x),
                         });
-                        Ok(self.instr(ir::Type::Expr { id: t }, ir::Expr::Array { elems: vars }))
+                        Ok(self.instr(ty, ir::Expr::Array { elems: vars }))
                     }
                     None => Err(TypeError::EmptyVec),
                 }
@@ -262,46 +234,40 @@ impl<'input, 'a> BlockCtx<'input, 'a> {
             ast::Expr::Index { val, index } => {
                 let v = self.typecheck(*val)?;
                 let i = self.typecheck(*index)?; // TODO: check index type
-                let t = match self.getlocal(v) {
-                    ir::Type::Expr { id } => match self.gettype(id) {
-                        ir::Typexpr::Ref { .. } => Err(TypeError::IndexRef),
-                        ir::Typexpr::Array { elem, .. } => Ok(*elem),
-                        ir::Typexpr::Tuple { .. } => Err(TypeError::IndexTuple),
-                        ir::Typexpr::Def { id: _, params: _ } => todo!(),
-                    },
-                    t => Err(TypeError::IndexPrimitive { t }),
+                let t = match self.gettype(self.getlocal(v)) {
+                    ir::Ty::Ref { .. } => Err(TypeError::IndexRef),
+                    &ir::Ty::Array { elem, .. } => Ok(elem),
+                    ir::Ty::Tuple { .. } => Err(TypeError::IndexTuple),
+                    t => Err(TypeError::IndexPrimitive { t: t.clone() }),
                 }?;
                 Ok(self.instr(t, ir::Expr::Index { array: v, index: i }))
             }
             ast::Expr::Member { val, member } => {
                 let tuple = self.typecheck(*val)?;
-                match self.getlocal(tuple) {
-                    ir::Type::Expr { id } => match self.gettype(id) {
-                        ir::Typexpr::Ref { .. } => Err(TypeError::MemberRef),
-                        ir::Typexpr::Array { index: _, elem } => {
-                            let i = match member.val {
-                                // TODO: check against vector size
-                                "r" | "x" => Ok(0),
-                                "g" | "y" => Ok(1),
-                                "b" | "z" => Ok(2),
-                                "a" | "w" => Ok(3),
-                                // TODO: allow multi-character swizzles
-                                _ => Err(TypeError::BadSwizzle {
-                                    swizzle: member.span(),
-                                }),
-                            }?;
-                            Ok(self.instr(
-                                *elem,
-                                ir::Expr::Member {
-                                    tuple,
-                                    member: id::member(i),
-                                },
-                            ))
-                        }
-                        ir::Typexpr::Tuple { members: _ } => todo!(),
-                        ir::Typexpr::Def { id: _, params: _ } => todo!(),
-                    },
-                    t => Err(TypeError::MemberPrimitive { t }),
+                match self.gettype(self.getlocal(tuple)) {
+                    ir::Ty::Ref { .. } => Err(TypeError::MemberRef),
+                    ir::Ty::Array { index: _, elem } => {
+                        let i = match member.val {
+                            // TODO: check against vector size
+                            "r" | "x" => Ok(0),
+                            "g" | "y" => Ok(1),
+                            "b" | "z" => Ok(2),
+                            "a" | "w" => Ok(3),
+                            // TODO: allow multi-character swizzles
+                            _ => Err(TypeError::BadSwizzle {
+                                swizzle: member.span(),
+                            }),
+                        }?;
+                        Ok(self.instr(
+                            *elem,
+                            ir::Expr::Member {
+                                tuple,
+                                member: id::member(i),
+                            },
+                        ))
+                    }
+                    ir::Ty::Tuple { members: _ } => todo!(),
+                    t => Err(TypeError::MemberPrimitive { t: t.clone() }),
                 }
             }
             ast::Expr::Let { bind, val, body } => {
@@ -314,26 +280,29 @@ impl<'input, 'a> BlockCtx<'input, 'a> {
                     .into_iter()
                     .map(|elem| self.typecheck(elem))
                     .collect::<Result<Vec<id::Var>, TypeError>>()?;
-                let types: Vec<ir::Type> = vars.iter().map(|&v| self.getlocal(v)).collect();
-                if let Some(&id) = self.m.funcnames.get(func.val) {
-                    let (generics, ret) = self.unify(&self.m.funcs[id.function()], &types)?;
-                    let func = self.newfunc(ir::Func { id, generics });
-                    let t = self.newtype(ir::Typexpr::Tuple { members: types });
-                    let arg =
-                        self.instr(ir::Type::Expr { id: t }, ir::Expr::Tuple { members: vars });
+                let types: Vec<id::Ty> = vars.iter().map(|&v| self.getlocal(v)).collect();
+                if let Some((i, _, f)) = self.m.funcs.get_full(func.val) {
+                    let (generics, ret) = self.unify(f, &types)?;
+                    let func = self.newfunc(ir::Func {
+                        id: id::function(i),
+                        generics,
+                    });
+                    let ty = self.newtype(ir::Ty::Tuple { members: types });
+                    let arg = self.instr(ty, ir::Expr::Tuple { members: vars });
                     Ok(self.instr(ret, ir::Expr::Call { func, arg }))
                 } else {
+                    let real = self.newtype(ir::Ty::F64);
                     // TODO: validate argument types for builtin functions
                     match func.val {
                         "abs" => Ok(self.instr(
-                            ir::Type::F64,
+                            real,
                             ir::Expr::Unary {
                                 op: ir::Unop::Abs,
                                 arg: vars[0],
                             },
                         )),
                         "sqrt" => Ok(self.instr(
-                            ir::Type::F64,
+                            real,
                             ir::Expr::Unary {
                                 op: ir::Unop::Abs,
                                 arg: vars[0],
@@ -349,7 +318,9 @@ impl<'input, 'a> BlockCtx<'input, 'a> {
                 // the `BlockCtx` type can only think about one under-construction block at a time,
                 // so when constructing an `If`, we keep swapping them out until we're done
 
-                let arg_then = self.newlocal(ir::Type::Unit);
+                let unit = self.newtype(ir::Ty::Unit);
+
+                let arg_then = self.newlocal(unit);
                 let ret_then = self.typecheck(*then)?;
                 let block_then = id::block(self.b.len());
                 let code_then = std::mem::take(&mut self.c);
@@ -359,7 +330,7 @@ impl<'input, 'a> BlockCtx<'input, 'a> {
                     ret: ret_then,
                 });
 
-                let arg_els = self.newlocal(ir::Type::Unit);
+                let arg_els = self.newlocal(unit);
                 let ret_els = self.typecheck(*els)?;
                 let block_els = id::block(self.b.len());
                 let code_els = std::mem::replace(&mut self.c, code);
@@ -383,7 +354,7 @@ impl<'input, 'a> BlockCtx<'input, 'a> {
                     .g
                     .get(limit.val)
                     .ok_or_else(|| TypeError::UnknownVar { name: limit.span() })?;
-                let i = ir::Type::Generic { id };
+                let i = self.newtype(ir::Ty::Generic { id });
                 let code = std::mem::take(&mut self.c);
 
                 let arg = self.newlocal(i);
@@ -397,30 +368,31 @@ impl<'input, 'a> BlockCtx<'input, 'a> {
                     ret: elem,
                 });
 
-                let v = self.newtype(ir::Typexpr::Array {
+                let v = self.newtype(ir::Ty::Array {
                     index: i,
                     elem: self.getlocal(elem),
                 });
-                Ok(self.instr(ir::Type::Expr { id: v }, ir::Expr::For { index: i, body }))
+                Ok(self.instr(v, ir::Expr::For { index: i, body }))
             }
             ast::Expr::Unary { op: _, arg: _ } => todo!(),
             ast::Expr::Binary { op, left, right } => {
+                let real = self.newtype(ir::Ty::F64);
                 let l = self.typecheck(*left)?;
                 let r = self.typecheck(*right)?;
                 let (t, binop) = match op {
-                    tokens::Binop::Add => (ir::Type::F64, ir::Binop::Add),
-                    tokens::Binop::Sub => (ir::Type::F64, ir::Binop::Sub),
-                    tokens::Binop::Mul => (ir::Type::F64, ir::Binop::Mul),
-                    tokens::Binop::Div => (ir::Type::F64, ir::Binop::Div),
+                    tokens::Binop::Add => (real, ir::Binop::Add),
+                    tokens::Binop::Sub => (real, ir::Binop::Sub),
+                    tokens::Binop::Mul => (real, ir::Binop::Mul),
+                    tokens::Binop::Div => (real, ir::Binop::Div),
                     tokens::Binop::Mod => todo!(),
-                    tokens::Binop::Eq => (ir::Type::F64, ir::Binop::Eq),
-                    tokens::Binop::Neq => (ir::Type::F64, ir::Binop::Neq),
-                    tokens::Binop::Lt => (ir::Type::F64, ir::Binop::Lt),
-                    tokens::Binop::Gt => (ir::Type::F64, ir::Binop::Gt),
-                    tokens::Binop::Leq => (ir::Type::F64, ir::Binop::Leq),
-                    tokens::Binop::Geq => (ir::Type::F64, ir::Binop::Geq),
-                    tokens::Binop::And => (ir::Type::F64, ir::Binop::And),
-                    tokens::Binop::Or => (ir::Type::F64, ir::Binop::Or),
+                    tokens::Binop::Eq => (real, ir::Binop::Eq),
+                    tokens::Binop::Neq => (real, ir::Binop::Neq),
+                    tokens::Binop::Lt => (real, ir::Binop::Lt),
+                    tokens::Binop::Gt => (real, ir::Binop::Gt),
+                    tokens::Binop::Leq => (real, ir::Binop::Leq),
+                    tokens::Binop::Geq => (real, ir::Binop::Geq),
+                    tokens::Binop::And => (real, ir::Binop::And),
+                    tokens::Binop::Or => (real, ir::Binop::Or),
                 };
                 let expr = ir::Expr::Binary {
                     op: binop,
@@ -437,33 +409,26 @@ impl<'input> Module<'input> {
     fn define(&mut self, def: ast::Def<'input>) -> Result<(), TypeError> {
         match def {
             ast::Def::Type { name, mut members } => {
+                let mut typevars = IndexSet::new();
                 // TODO: check for duplicate field names
                 members.sort_by_key(|&(name, _)| name); // to ignore field order in literals
-                let (genericnames, mut typevars, fields) = parse_types(
-                    |s| self.typenames.get(s).copied(),
+                let (_, fields) = parse_types(
+                    |s| self.types.get(s),
+                    &mut typevars,
                     members.iter().map(|&(_, t)| t),
                 )?;
-                let def = ir::Type::Expr {
-                    id: id::typexpr(typevars.len()),
-                };
-                typevars.push(ir::Typexpr::Tuple { members: fields });
-                let t = ir::Typedef {
-                    generics: vec![EnumSet::only(ir::Constraint::Index); genericnames.len()],
-                    types: typevars,
-                    def,
-                    // TODO: check constraints once the text syntax supports non-vector structs
-                    constraints: EnumSet::only(ir::Constraint::Vector),
-                };
-                let id = id::typedef(self.types.len());
-                self.types.push(Type {
-                    def: t,
-                    fields: members
-                        .into_iter()
-                        .map(|(name, _)| name)
-                        .collect::<Vec<_>>(),
-                });
                 // TODO: check for duplicate type names
-                self.typenames.insert(name, id);
+                self.types.insert(
+                    name,
+                    Typedef {
+                        types: typevars.into_iter().collect(),
+                        fields: members
+                            .into_iter()
+                            .map(|(_, t)| t.val)
+                            .zip(fields)
+                            .collect(),
+                    },
+                );
             }
             ast::Def::Func {
                 name,
@@ -471,19 +436,19 @@ impl<'input> Module<'input> {
                 typ,
                 body,
             } => {
-                let (genericnames, mut typevars, mut paramtypes) = parse_types(
-                    |s| self.typenames.get(s).copied(),
+                let mut typevars = IndexSet::new();
+                let (genericnames, mut paramtypes) = parse_types(
+                    |s| self.types.get(s),
+                    &mut typevars,
                     // TODO: handle return type separately from params w.r.t. generics
                     params.iter().map(|&(_, t)| t).chain([typ]),
                 )?;
                 let generics = vec![EnumSet::only(ir::Constraint::Index); genericnames.len()];
                 let ret = paramtypes.pop().expect("`parse_types` should preserve len");
-                let param = ir::Type::Expr {
-                    id: id::typexpr(typevars.len()),
-                };
-                typevars.push(ir::Typexpr::Tuple {
+                let (param_id, _) = typevars.insert_full(ir::Ty::Tuple {
                     members: paramtypes.clone(), // should be a way to do this without `clone`...
                 });
+                let param = id::ty(param_id);
                 let arg = id::var(0);
                 let mut ctx = BlockCtx {
                     m: self,
@@ -512,7 +477,7 @@ impl<'input> Module<'input> {
                 });
                 let f = ir::Function {
                     generics,
-                    types: ctx.t,
+                    types: ctx.t.into_iter().collect(),
                     funcs: ctx.f,
                     param,
                     ret,
@@ -520,10 +485,8 @@ impl<'input> Module<'input> {
                     blocks: ctx.b,
                     main,
                 };
-                let id = id::function(self.funcs.len());
-                self.funcs.push(f);
                 // TODO: check for duplicate function names
-                self.funcnames.insert(name, id);
+                self.funcs.insert(name, f);
             }
         }
         Ok(())
@@ -532,10 +495,8 @@ impl<'input> Module<'input> {
 
 pub fn translate(ast: ast::Module) -> Result<Module, TypeError> {
     let mut m = Module {
-        types: vec![],
-        funcs: vec![],
-        typenames: HashMap::new(),
-        funcnames: HashMap::new(),
+        types: IndexMap::new(),
+        funcs: IndexMap::new(),
     };
     for def in ast.defs {
         m.define(def)?;

--- a/crates/frontend/tests/interp.rs
+++ b/crates/frontend/tests/interp.rs
@@ -1,3 +1,4 @@
+use indexmap::IndexSet;
 use rose_frontend::parse;
 use rose_interp::{interp, Val};
 use std::rc::Rc;
@@ -8,6 +9,7 @@ fn test_add() {
     let module = parse(src).unwrap();
     let answer = interp(
         module.get_func("add").unwrap(),
+        IndexSet::new(),
         &[],
         Val::Tuple(Rc::new(vec![Val::F64(2.), Val::F64(2.)])),
     )
@@ -21,6 +23,7 @@ fn test_sub() {
     let module = parse(src).unwrap();
     let answer = interp(
         module.get_func("sub").unwrap(),
+        IndexSet::new(),
         &[],
         Val::Tuple(Rc::new(vec![Val::F64(2.), Val::F64(2.)])),
     )

--- a/crates/interp/Cargo.toml
+++ b/crates/interp/Cargo.toml
@@ -5,6 +5,7 @@ publish = false
 edition = "2021"
 
 [dependencies]
+indexmap = "2"
 rose = { path = "../core" }
 serde = { version = "1", features = ["derive", "rc"], optional = true }
 thiserror = "1"

--- a/crates/interp/src/lib.rs
+++ b/crates/interp/src/lib.rs
@@ -89,6 +89,14 @@ fn zero(types: &IndexSet<Ty>, ty: id::Ty) -> Val {
     }
 }
 
+/// Resolve `ty` via `generics` and `types`, then return its ID in `typemap`, inserting if need be.
+///
+/// This is meant to be used to pull all the types from a callee into a broader context. The
+/// `generics` are the IDs of all the types provided as generic type parameters for the callee. The
+/// `types are the IDs of all the types that have been pulled in so far.
+///
+/// The interpreter is meant to be used with no generic "free variables," and does not do any scope
+/// checking, so all scopes are replaced with a block ID of zero.
 fn resolve(typemap: &mut IndexSet<Ty>, generics: &[id::Ty], types: &[id::Ty], ty: &Ty) -> id::Ty {
     let resolved = match ty {
         Ty::Generic { id } => return generics[id.generic()],

--- a/crates/interp/src/lib.rs
+++ b/crates/interp/src/lib.rs
@@ -1,4 +1,5 @@
-use rose::{id, Binop, Expr, FuncNode, Type, Typexpr, Unop};
+use indexmap::IndexSet;
+use rose::{id, Binop, Expr, FuncNode, Ty, Unop};
 use std::{cell::Cell, rc::Rc};
 
 #[cfg(feature = "serde")]
@@ -6,30 +7,6 @@ use serde::{Deserialize, Serialize};
 
 #[cfg(test)]
 use ts_rs::TS;
-
-/// A resolved type.
-#[cfg_attr(test, derive(TS), ts(export))]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug)]
-pub enum Typeval {
-    Unit,
-    Bool,
-    F64,
-    Fin {
-        size: usize,
-    },
-    Scope, // we erase scope info in the interpreter
-    Ref {
-        inner: Rc<Typeval>,
-    },
-    Array {
-        index: Rc<Typeval>,
-        elem: Rc<Typeval>,
-    },
-    Tuple {
-        members: Rc<Vec<Typeval>>,
-    },
-}
 
 #[cfg_attr(test, derive(TS), ts(export))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -56,25 +33,6 @@ impl Val {
         match self {
             &Val::F64(x) => x,
             _ => unreachable!(),
-        }
-    }
-}
-
-impl Typeval {
-    /// Return zero a value of `Ref` type for this type, which must satisfy `Constraint::Vector`.
-    fn zero(&self) -> Val {
-        match self {
-            Self::F64 => Val::Ref(Rc::new(Cell::new(0.))),
-            Self::Array { index, elem } => match index.as_ref() {
-                &Typeval::Fin { size } => Val::Array(Rc::new(vec![elem.as_ref().zero(); size])),
-                _ => unreachable!(),
-            },
-            Self::Tuple { members } => {
-                Val::Tuple(Rc::new(members.iter().map(|x| x.zero()).collect()))
-            }
-            Self::Unit | Self::Bool | Self::Fin { .. } | Self::Scope | Self::Ref { .. } => {
-                unreachable!()
-            }
         }
     }
 }
@@ -111,59 +69,71 @@ impl Val {
     }
 }
 
-fn resolve(generics: &[Typeval], types: &[Typeval], t: Type) -> Typeval {
-    match t {
-        Type::Unit => Typeval::Unit,
-        Type::Bool => Typeval::Bool,
-        Type::F64 => Typeval::F64,
-        Type::Fin { size } => Typeval::Fin { size },
-        Type::Generic { id } => generics[id.generic()].clone(),
-        Type::Scope { id: _ } => Typeval::Scope,
-        Type::Expr { id } => types[id.typexpr()].clone(),
+/// Return zero a value of `Ref` type for this type, which must satisfy `Constraint::Vector`.
+fn zero(types: &IndexSet<Ty>, ty: id::Ty) -> Val {
+    match &types[ty.ty()] {
+        Ty::F64 => Val::Ref(Rc::new(Cell::new(0.))),
+        &Ty::Array { index, elem } => match types[index.ty()] {
+            Ty::Fin { size } => Val::Array(Rc::new((0..size).map(|_| zero(types, elem)).collect())),
+            _ => unreachable!(),
+        },
+        Ty::Tuple { members } => {
+            Val::Tuple(Rc::new(members.iter().map(|&x| zero(types, x)).collect()))
+        }
+        Ty::Unit
+        | Ty::Bool
+        | Ty::Fin { .. }
+        | Ty::Generic { .. }
+        | Ty::Scope { .. }
+        | Ty::Ref { .. } => unreachable!(),
     }
 }
 
+fn resolve(typemap: &mut IndexSet<Ty>, generics: &[id::Ty], types: &[id::Ty], ty: &Ty) -> id::Ty {
+    let resolved = match ty {
+        Ty::Generic { id } => return generics[id.generic()],
+
+        Ty::Unit => Ty::Unit,
+        Ty::Bool => Ty::Bool,
+        Ty::F64 => Ty::F64,
+        &Ty::Fin { size } => Ty::Fin { size },
+
+        Ty::Scope { id: _ } => Ty::Scope { id: id::block(0) }, // we erase scope info
+        Ty::Ref { scope, inner } => Ty::Ref {
+            scope: types[scope.ty()],
+            inner: types[inner.ty()],
+        },
+        Ty::Array { index, elem } => Ty::Array {
+            index: types[index.ty()],
+            elem: types[elem.ty()],
+        },
+        Ty::Tuple { members } => Ty::Tuple {
+            members: members.iter().map(|&x| types[x.ty()]).collect(),
+        },
+    };
+    let (i, _) = typemap.insert_full(resolved);
+    id::ty(i)
+}
+
 struct Interpreter<'a, F: FuncNode> {
+    typemap: &'a mut IndexSet<Ty>,
     f: &'a F, // reference instead of value because otherwise borrow checker complains in `fn block`
-    generics: &'a [Typeval],
-    types: Vec<Typeval>,
+    types: Vec<id::Ty>,
     vars: Vec<Option<Val>>,
 }
 
 impl<'a, F: FuncNode> Interpreter<'a, F> {
-    fn new(f: &'a F, generics: &'a [Typeval]) -> Self {
+    fn new(typemap: &'a mut IndexSet<Ty>, f: &'a F, generics: &'a [id::Ty]) -> Self {
         let mut types = vec![];
-        for t in &f.def().types {
-            let v = match t {
-                &Typexpr::Ref { scope: _, inner } => Typeval::Ref {
-                    inner: Rc::new(resolve(generics, &types, inner)),
-                },
-                &Typexpr::Array { index, elem } => Typeval::Array {
-                    index: Rc::new(resolve(generics, &types, index)),
-                    elem: Rc::new(resolve(generics, &types, elem)),
-                },
-                Typexpr::Tuple { members } => Typeval::Tuple {
-                    members: Rc::new(
-                        members
-                            .iter()
-                            .map(|x| resolve(generics, &types, *x))
-                            .collect(),
-                    ),
-                },
-                Typexpr::Def { id: _, params: _ } => todo!(),
-            };
-            types.push(v);
+        for ty in &f.def().types {
+            types.push(resolve(typemap, generics, &types, ty));
         }
         Self {
+            typemap,
             f,
-            generics,
             types,
             vars: vec![None; f.def().vars.len()],
         }
-    }
-
-    fn resolve(&self, t: Type) -> Typeval {
-        resolve(self.generics, &self.types, t)
     }
 
     fn get(&self, var: id::Var) -> &Val {
@@ -238,8 +208,14 @@ impl<'a, F: FuncNode> Interpreter<'a, F> {
 
             &Expr::Call { func, arg } => {
                 let f = &self.f.def().funcs[func.func()];
-                let generics: Vec<Typeval> = f.generics.iter().map(|&t| self.resolve(t)).collect();
-                call(self.f.func(f.id).unwrap(), &generics, self.get(arg).clone())
+                let generics: Vec<id::Ty> =
+                    f.generics.iter().map(|id| self.types[id.ty()]).collect();
+                call(
+                    self.f.get(f.id).unwrap(),
+                    self.typemap,
+                    &generics,
+                    self.get(arg).clone(),
+                )
             }
             &Expr::If { cond, then, els } => {
                 if self.get(cond).bool() {
@@ -249,8 +225,8 @@ impl<'a, F: FuncNode> Interpreter<'a, F> {
                 }
             }
             &Expr::For { index, body } => {
-                let n = match self.resolve(index) {
-                    Typeval::Fin { size } => size,
+                let n = match self.typemap[self.types[index.ty()].ty()] {
+                    Ty::Fin { size } => size,
                     _ => unreachable!(),
                 };
                 let v: Vec<Val> = (0..n)
@@ -259,7 +235,7 @@ impl<'a, F: FuncNode> Interpreter<'a, F> {
                 Val::Array(Rc::new(v))
             }
             &Expr::Accum { var, vector, body } => {
-                let x = self.resolve(vector).zero();
+                let x = zero(self.typemap, self.types[vector.ty()]);
                 let y = self.block(body, x.clone()).clone();
                 self.vars[var.var()] = Some(x.immut());
                 y
@@ -283,8 +259,8 @@ impl<'a, F: FuncNode> Interpreter<'a, F> {
 }
 
 /// Assumes `generics` and `arg` are valid.
-fn call(f: impl FuncNode, generics: &[Typeval], arg: Val) -> Val {
-    Interpreter::new(&f, generics)
+fn call(f: impl FuncNode, types: &mut IndexSet<Ty>, generics: &[id::Ty], arg: Val) -> Val {
+    Interpreter::new(types, &f, generics)
         .block(f.def().main, arg)
         .clone()
 }
@@ -293,28 +269,20 @@ fn call(f: impl FuncNode, generics: &[Typeval], arg: Val) -> Val {
 pub enum Error {}
 
 /// Guaranteed not to panic if `f` is valid.
-pub fn interp(f: impl FuncNode, generics: &[Typeval], arg: Val) -> Result<Val, Error> {
+pub fn interp(
+    f: impl FuncNode,
+    mut types: IndexSet<Ty>,
+    generics: &[id::Ty],
+    arg: Val,
+) -> Result<Val, Error> {
     // TODO: check that `generics` and `arg` are valid
-    Ok(call(f, generics, arg))
+    Ok(call(f, &mut types, generics, arg))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rose::{Block, Func, Function, Instr, TypeNode};
-
-    #[derive(Clone, Copy, Debug)]
-    enum NoTypedefs {}
-
-    impl TypeNode for NoTypedefs {
-        fn def(&self) -> &rose::Typedef {
-            match *self {}
-        }
-
-        fn ty(&self, _id: id::Typedef) -> Option<Self> {
-            None
-        }
-    }
+    use rose::{Block, Func, Function, Instr};
 
     #[derive(Clone, Copy, Debug)]
     struct FuncInSlice<'a> {
@@ -323,17 +291,11 @@ mod tests {
     }
 
     impl FuncNode for FuncInSlice<'_> {
-        type Ty = NoTypedefs;
-
         fn def(&self) -> &Function {
             &self.funcs[self.id.function()]
         }
 
-        fn ty(&self, _id: id::Typedef) -> Option<Self::Ty> {
-            None
-        }
-
-        fn func(&self, id: id::Function) -> Option<Self> {
+        fn get(&self, id: id::Function) -> Option<Self> {
             Some(Self {
                 funcs: self.funcs,
                 id,
@@ -345,18 +307,16 @@ mod tests {
     fn test_two_plus_two() {
         let funcs = vec![Function {
             generics: vec![],
-            types: vec![Typexpr::Tuple {
-                members: vec![Type::F64, Type::F64],
-            }],
-            funcs: vec![],
-            param: Type::Expr { id: id::typexpr(0) },
-            ret: Type::F64,
-            vars: vec![
-                Type::Expr { id: id::typexpr(0) },
-                Type::F64,
-                Type::F64,
-                Type::F64,
+            types: vec![
+                Ty::F64,
+                Ty::Tuple {
+                    members: vec![id::ty(0), id::ty(0)],
+                },
             ],
+            funcs: vec![],
+            param: id::ty(1),
+            ret: id::ty(0),
+            vars: vec![id::ty(1), id::ty(0), id::ty(0), id::ty(0)],
             blocks: vec![Block {
                 arg: id::var(0),
                 code: vec![
@@ -392,6 +352,7 @@ mod tests {
                 funcs: &funcs,
                 id: id::function(0),
             },
+            IndexSet::new(),
             &[],
             Val::Tuple(Rc::new(vec![Val::F64(2.), Val::F64(2.)])),
         )
@@ -404,11 +365,11 @@ mod tests {
         let funcs = vec![
             Function {
                 generics: vec![],
-                types: vec![],
+                types: vec![Ty::Unit, Ty::F64],
                 funcs: vec![],
-                param: Type::Unit,
-                ret: Type::F64,
-                vars: vec![Type::Unit, Type::F64],
+                param: id::ty(0),
+                ret: id::ty(1),
+                vars: vec![id::ty(0), id::ty(1)],
                 blocks: vec![Block {
                     arg: id::var(0),
                     code: vec![Instr {
@@ -421,14 +382,14 @@ mod tests {
             },
             Function {
                 generics: vec![],
-                types: vec![],
+                types: vec![Ty::Unit, Ty::F64],
                 funcs: vec![Func {
                     id: id::function(0),
                     generics: vec![],
                 }],
-                param: Type::Unit,
-                ret: Type::F64,
-                vars: vec![Type::Unit, Type::F64, Type::F64],
+                param: id::ty(0),
+                ret: id::ty(1),
+                vars: vec![id::ty(0), id::ty(1), id::ty(1)],
                 blocks: vec![Block {
                     arg: id::var(0),
                     code: vec![
@@ -458,6 +419,7 @@ mod tests {
                 funcs: &funcs,
                 id: id::function(1),
             },
+            IndexSet::new(),
             &[],
             Val::Unit,
         )

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["cdylib"]
 [dependencies]
 console_error_panic_hook = { version = "0.1", optional = true }
 enumset = "1"
+indexmap = { version = "2", features = ["serde"] }
 rose = { path = "../core", features = ["serde"] }
 rose-interp = { path = "../interp", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -1,4 +1,5 @@
 use enumset::EnumSet;
+use indexmap::IndexSet;
 use rose::id;
 use serde::Serialize;
 use std::rc::Rc;
@@ -34,50 +35,25 @@ pub fn layouts() -> Result<JsValue, serde_wasm_bindgen::Error> {
     to_js_value(&[
         ("Expr", layout::<rose::Expr>()),
         ("Instr", layout::<rose::Instr>()),
-        ("Type", layout::<rose::Type>()),
-        ("Typexpr", layout::<rose::Typexpr>()),
+        ("Ty", layout::<rose::Ty>()),
     ])
-}
-
-#[derive(Clone, Debug)]
-pub struct Ty {
-    rc: Rc<(Vec<Ty>, rose::Typedef)>,
-}
-
-impl rose::TypeNode for &Ty {
-    fn def(&self) -> &rose::Typedef {
-        let (_, def) = self.rc.as_ref();
-        def
-    }
-
-    fn ty(&self, id: id::Typedef) -> Option<Self> {
-        let (types, _) = self.rc.as_ref();
-        types.get(id.typedef())
-    }
 }
 
 /// A node in a reference-counted acyclic digraph of functions.
 #[wasm_bindgen]
 #[derive(Clone, Debug)]
 pub struct Func {
-    rc: Rc<(Vec<Ty>, Vec<Func>, rose::Function)>,
+    rc: Rc<(Vec<Func>, rose::Function)>,
 }
 
 impl<'a> rose::FuncNode for &'a Func {
-    type Ty = &'a Ty;
-
     fn def(&self) -> &rose::Function {
-        let (_, _, def) = self.rc.as_ref();
+        let (_, def) = self.rc.as_ref();
         def
     }
 
-    fn ty(&self, id: id::Typedef) -> Option<Self::Ty> {
-        let (types, _, _) = self.rc.as_ref();
-        types.get(id.typedef())
-    }
-
-    fn func(&self, id: id::Function) -> Option<Self> {
-        let (_, funcs, _) = self.rc.as_ref();
+    fn get(&self, id: id::Function) -> Option<Self> {
+        let (funcs, _) = self.rc.as_ref();
         funcs.get(id.function())
     }
 }
@@ -85,7 +61,7 @@ impl<'a> rose::FuncNode for &'a Func {
 #[cfg(feature = "debug")]
 #[wasm_bindgen(js_name = "js2Rust")]
 pub fn js_to_rust(f: &Func) -> String {
-    let (_, _, def) = f.rc.as_ref();
+    let (_, def) = f.rc.as_ref();
     format!("{:#?}", def)
 }
 
@@ -94,13 +70,11 @@ pub fn js_to_rust(f: &Func) -> String {
 pub struct Context {
     functions: Vec<Func>,
     generics: Vec<EnumSet<rose::Constraint>>,
-    types: Vec<rose::Typexpr>,
-    funcs: Vec<rose::Func>,
-    /// Return type for every function in `funcs`. Must always be the same length as `funcs`.
-    ret_types: Vec<rose::Type>,
-    param: rose::Type,
-    ret: rose::Type,
-    vars: Vec<rose::Type>,
+    types: IndexSet<rose::Ty>,
+    funcs: Vec<(rose::Func, id::Ty)>,
+    param: id::Ty,
+    ret: id::Ty,
+    vars: Vec<id::Ty>,
     blocks: Vec<rose::Block>,
 }
 
@@ -111,7 +85,6 @@ pub fn bake(ctx: Context, main: usize) -> Func {
         generics,
         types,
         funcs,
-        ret_types: _,
         param,
         ret,
         vars,
@@ -119,12 +92,11 @@ pub fn bake(ctx: Context, main: usize) -> Func {
     } = ctx;
     Func {
         rc: Rc::new((
-            vec![], // TODO: support typedefs
             functions,
             rose::Function {
                 generics,
-                types,
-                funcs,
+                types: types.into_iter().collect(),
+                funcs: funcs.into_iter().map(|(f, _)| f).collect(),
                 param,
                 ret,
                 vars,
@@ -189,24 +161,27 @@ impl Body {
     }
 }
 
-/// The `param_types` argument is Serde-converted to `Vec<rose::Type>`, and the `ret_type`
-/// argument is Serde-converted to `rose::Type`.
-///
-/// TODO: currently no support for non-primitive types
+/// The `types` argument is Serde-converted to `indexmap::IndexSet<rose::Ty>`.
 #[wasm_bindgen]
-pub fn make(generics: usize, param_types: JsValue, ret_type: JsValue) -> Result<Body, JsError> {
-    let params: Vec<rose::Type> = serde_wasm_bindgen::from_value(param_types)?;
-    let ret: rose::Type = serde_wasm_bindgen::from_value(ret_type)?;
+pub fn make(
+    generics: usize,
+    types: JsValue,
+    params: Vec<usize>,
+    ret: usize,
+) -> Result<Body, JsError> {
+    let mut types: IndexSet<rose::Ty> = serde_wasm_bindgen::from_value(types)?;
 
-    let param = rose::Type::Expr { id: id::typexpr(0) };
+    let (param, _) = types.insert_full(rose::Ty::Tuple {
+        members: params.iter().map(|&i| id::ty(i)).collect(),
+    });
+    let param = id::ty(param);
     let mut ctx = Context {
         functions: vec![],
         generics: vec![EnumSet::only(rose::Constraint::Index); generics],
-        types: vec![], // we populate this further down
+        types,
         funcs: vec![],
-        ret_types: vec![],
         param,
-        ret,
+        ret: id::ty(ret),
         vars: vec![],
         blocks: vec![],
     };
@@ -216,15 +191,14 @@ pub fn make(generics: usize, param_types: JsValue, ret_type: JsValue) -> Result<
     let args = params
         .iter()
         .enumerate()
-        .map(|(i, &t)| {
+        .map(|(i, &ty)| {
             let expr = rose::Expr::Member {
                 tuple: arg,
                 member: id::member(i),
             };
-            ctx.instr(&mut main, t, expr)
+            ctx.instr(&mut main, id::ty(ty), expr)
         })
         .collect();
-    ctx.types.push(rose::Typexpr::Tuple { members: params });
 
     Ok(Body {
         ctx: Some(ctx),
@@ -234,46 +208,61 @@ pub fn make(generics: usize, param_types: JsValue, ret_type: JsValue) -> Result<
     })
 }
 
+/// Resolve `ty` via `generics` and `types`, then return its ID in `typemap`, inserting if need be.
+///
+/// This is meant to be used to pull all the types from a callee into a broader context. The
+/// `generics` are the IDs of all the types provided as generic type parameters for the callee. The
+/// `types are the IDs of all the types that have been pulled in so far.
+///
+/// The element type of `types`, and the return type of this function, use `Option` because some
+/// types from the callee may be ignored, specifically those that reference internal scopes. These
+/// cannot appear in the callee's signature if it is a valid function, so we can simply turn them
+/// into `None` and propagate those through if we find further types that depend on them.
+fn resolve(
+    typemap: &mut IndexSet<rose::Ty>,
+    generics: &[usize],
+    types: &[Option<id::Ty>],
+    ty: &rose::Ty,
+) -> Option<id::Ty> {
+    let resolved = match ty {
+        // inner scopes cannot appear in the return type, which is all we care about here
+        rose::Ty::Scope { id: _ } => return None,
+        rose::Ty::Generic { id } => return Some(id::ty(generics[id.generic()])),
+
+        rose::Ty::Unit => rose::Ty::Unit,
+        rose::Ty::Bool => rose::Ty::Bool,
+        rose::Ty::F64 => rose::Ty::F64,
+        &rose::Ty::Fin { size } => rose::Ty::Fin { size },
+
+        rose::Ty::Ref { scope, inner } => rose::Ty::Ref {
+            scope: types[scope.ty()]?,
+            inner: types[inner.ty()]?,
+        },
+        rose::Ty::Array { index, elem } => rose::Ty::Array {
+            index: types[index.ty()]?,
+            elem: types[elem.ty()]?,
+        },
+        rose::Ty::Tuple { members } => rose::Ty::Tuple {
+            members: members
+                .iter()
+                .map(|&x| types[x.ty()])
+                .collect::<Option<_>>()?,
+        },
+    };
+    let (i, _) = typemap.insert_full(resolved);
+    Some(id::ty(i))
+}
+
 // TODO: catch invalid user-given indices instead of panicking
 #[wasm_bindgen]
 impl Context {
-    /// `generics` is Serde-converted to `Vec<rose::Type>`.
     #[wasm_bindgen]
-    pub fn func(&mut self, f: &Func, generics: JsValue) -> Result<usize, JsError> {
-        let types: Vec<rose::Type> = serde_wasm_bindgen::from_value(generics)?;
-
-        // only valid if indeed the `for` loop below calls `push` exactly once per iteration
-        let n = self.types.len();
-        // translate types from the callee to the caller
-        let translate = |t: rose::Type| -> rose::Type {
-            match t {
-                rose::Type::Unit | rose::Type::Bool | rose::Type::F64 | rose::Type::Fin { .. } => t,
-                rose::Type::Generic { id } => types[id.generic()],
-                rose::Type::Scope { id: _ } => todo!(),
-                rose::Type::Expr { id } => rose::Type::Expr {
-                    id: id::typexpr(id.typexpr() - n),
-                },
-            }
-        };
-
-        let (_, _, def) = f.rc.as_ref();
+    pub fn func(&mut self, f: &Func, generics: &[usize]) -> Result<usize, JsError> {
+        let mut types = vec![];
+        let (_, def) = f.rc.as_ref();
         // push a corresponding type onto our own `types` for each type in the callee
         for callee_type in &def.types {
-            let caller_type = match callee_type {
-                &rose::Typexpr::Ref { scope, inner } => rose::Typexpr::Ref {
-                    scope: translate(scope),
-                    inner: translate(inner),
-                },
-                &rose::Typexpr::Array { index, elem } => rose::Typexpr::Array {
-                    index: translate(index),
-                    elem: translate(elem),
-                },
-                rose::Typexpr::Tuple { members } => rose::Typexpr::Tuple {
-                    members: members.iter().map(|&t| translate(t)).collect(),
-                },
-                rose::Typexpr::Def { id: _, params: _ } => todo!(),
-            };
-            self.types.push(caller_type);
+            types.push(resolve(&mut self.types, generics, &types, callee_type));
         }
 
         // push the function reference to the callee
@@ -282,11 +271,15 @@ impl Context {
 
         // push data about the callee's interface types
         let func_id = self.funcs.len();
-        self.ret_types.push(translate(def.ret));
-        self.funcs.push(rose::Func {
-            generics: types,
-            id: function_id,
-        });
+        self.funcs.push((
+            rose::Func {
+                generics: generics.iter().map(|&i| id::ty(i)).collect(),
+                id: function_id,
+            },
+            // the only types we omitted were inner scopes from the callee, which cannot appear in
+            // its return type
+            types[def.ret.ty()].unwrap(),
+        ));
         Ok(func_id)
     }
 
@@ -302,44 +295,29 @@ impl Context {
         id
     }
 
-    fn get(&self, var: id::Var) -> rose::Type {
+    fn get(&self, var: id::Var) -> id::Ty {
         self.vars[var.var()]
     }
 
-    fn var(&mut self, t: rose::Type) -> id::Var {
+    fn var(&mut self, t: id::Ty) -> id::Var {
         let id = self.vars.len();
         self.vars.push(t);
         id::var(id)
     }
 
-    fn typexpr(&mut self, t: rose::Typexpr) -> id::Typexpr {
-        let id = self.types.len();
-        self.types.push(t);
-        id::typexpr(id)
+    fn ty(&mut self, ty: rose::Ty) -> id::Ty {
+        let (i, _) = self.types.insert_full(ty);
+        id::ty(i)
     }
 
     // for `If`
     #[wasm_bindgen(js_name = "varUnit")]
     pub fn var_unit(&mut self) -> usize {
-        self.var(rose::Type::Unit).var()
+        let ty = self.ty(rose::Ty::Unit);
+        self.var(ty).var()
     }
 
-    // for `For`
-    #[wasm_bindgen(js_name = "varFin")]
-    pub fn var_fin(&mut self, size: usize) -> usize {
-        self.var(rose::Type::Fin { size }).var()
-    }
-
-    // for `For`
-    #[wasm_bindgen(js_name = "varGeneric")]
-    pub fn var_generic(&mut self, id: usize) -> usize {
-        self.var(rose::Type::Generic {
-            id: id::generic(id),
-        })
-        .var()
-    }
-
-    fn instr(&mut self, b: &mut Block, t: rose::Type, expr: rose::Expr) -> usize {
+    fn instr(&mut self, b: &mut Block, t: id::Ty, expr: rose::Expr) -> usize {
         let var = self.var(t);
         b.code.push(rose::Instr { var, expr });
         var.var()
@@ -347,77 +325,70 @@ impl Context {
 
     #[wasm_bindgen]
     pub fn unit(&mut self, b: &mut Block) -> usize {
-        self.instr(b, rose::Type::Unit, rose::Expr::Unit)
+        let ty = self.ty(rose::Ty::Unit);
+        self.instr(b, ty, rose::Expr::Unit)
     }
 
     #[wasm_bindgen]
     pub fn bool(&mut self, b: &mut Block, val: bool) -> usize {
-        self.instr(b, rose::Type::Bool, rose::Expr::Bool { val })
+        let ty = self.ty(rose::Ty::Bool);
+        self.instr(b, ty, rose::Expr::Bool { val })
     }
 
     #[wasm_bindgen]
     pub fn f64(&mut self, b: &mut Block, val: f64) -> usize {
-        self.instr(b, rose::Type::F64, rose::Expr::F64 { val })
+        let ty = self.ty(rose::Ty::F64);
+        self.instr(b, ty, rose::Expr::F64 { val })
     }
 
     #[wasm_bindgen]
     pub fn fin(&mut self, b: &mut Block, size: usize, val: usize) -> usize {
-        self.instr(b, rose::Type::Fin { size }, rose::Expr::Fin { val })
+        let ty = self.ty(rose::Ty::Fin { size });
+        self.instr(b, ty, rose::Expr::Fin { val })
     }
 
     #[wasm_bindgen]
-    pub fn array(&mut self, b: &mut Block, elems: Vec<usize>) -> Result<usize, JsError> {
-        // TODO: it would be nice if we could just reuse `elems` instead of making `xs`
+    pub fn array(&mut self, b: &mut Block, elems: &[usize]) -> Result<usize, JsError> {
         let xs: Vec<id::Var> = elems.iter().map(|&x| id::var(x)).collect();
         let &x = xs.get(0).ok_or_else(|| JsError::new("empty array"))?;
-        let t = self.typexpr(rose::Typexpr::Array {
-            index: rose::Type::Fin { size: xs.len() },
+        let index = self.ty(rose::Ty::Fin { size: xs.len() });
+        let ty = self.ty(rose::Ty::Array {
+            index,
             elem: self.get(x),
         });
         let expr = rose::Expr::Array { elems: xs };
-        Ok(self.instr(b, rose::Type::Expr { id: t }, expr))
+        Ok(self.instr(b, ty, expr))
     }
 
     #[wasm_bindgen]
-    pub fn tuple(&mut self, b: &mut Block, members: Vec<usize>) -> usize {
-        // TODO: it would be nice if we could just reuse `members` instead of making `xs`
+    pub fn tuple(&mut self, b: &mut Block, members: &[usize]) -> usize {
         let xs: Vec<id::Var> = members.iter().map(|&x| id::var(x)).collect();
         let types = xs.iter().map(|&x| self.get(x)).collect();
-        let t = self.typexpr(rose::Typexpr::Tuple { members: types });
+        let ty = self.ty(rose::Ty::Tuple { members: types });
         let expr = rose::Expr::Tuple { members: xs };
-        self.instr(b, rose::Type::Expr { id: t }, expr)
+        self.instr(b, ty, expr)
     }
 
     #[wasm_bindgen]
     pub fn index(&mut self, b: &mut Block, arr: usize, idx: usize) -> Result<usize, JsError> {
         let array = id::var(arr);
         let index = id::var(idx);
-        let &t = match self.get(array) {
-            rose::Type::Expr { id } => match &self.types[id.typexpr()] {
-                rose::Typexpr::Array { index: _, elem } => Some(elem),
-                rose::Typexpr::Def { id: _, params: _ } => todo!(),
-                rose::Typexpr::Ref { .. } | rose::Typexpr::Tuple { .. } => None,
-            },
-            _ => None,
-        }
-        .ok_or_else(|| JsError::new("not an array"))?;
-        Ok(self.instr(b, t, rose::Expr::Index { array, index }))
+        let ty = match self.types[self.get(array).ty()] {
+            rose::Ty::Array { index: _, elem } => elem,
+            _ => return Err(JsError::new("not an array")),
+        };
+        Ok(self.instr(b, ty, rose::Expr::Index { array, index }))
     }
 
     #[wasm_bindgen]
     pub fn member(&mut self, b: &mut Block, tup: usize, mem: usize) -> Result<usize, JsError> {
         let tuple = id::var(tup);
         let member = id::member(mem);
-        let t = match self.get(tuple) {
-            rose::Type::Expr { id } => match &self.types[id.typexpr()] {
-                rose::Typexpr::Tuple { members } => Some(members[mem]),
-                rose::Typexpr::Def { id: _, params: _ } => todo!(),
-                rose::Typexpr::Ref { .. } | rose::Typexpr::Array { .. } => None,
-            },
-            _ => None,
-        }
-        .ok_or_else(|| JsError::new("not a tuple"))?;
-        Ok(self.instr(b, t, rose::Expr::Member { tuple, member }))
+        let ty = match &self.types[self.get(tuple).ty()] {
+            rose::Ty::Tuple { members } => members[mem],
+            _ => return Err(JsError::new("not a tuple")),
+        };
+        Ok(self.instr(b, ty, rose::Expr::Member { tuple, member }))
     }
 
     // no `Expr::Slice` or `Expr::Field` here, because we don't currently expose mutation to JS
@@ -426,38 +397,42 @@ impl Context {
 
     #[wasm_bindgen]
     pub fn not(&mut self, b: &mut Block, arg: usize) -> usize {
+        let ty = self.ty(rose::Ty::Bool);
         let expr = rose::Expr::Unary {
             op: rose::Unop::Not,
             arg: id::var(arg),
         };
-        self.instr(b, rose::Type::Bool, expr)
+        self.instr(b, ty, expr)
     }
 
     #[wasm_bindgen]
     pub fn neg(&mut self, b: &mut Block, arg: usize) -> usize {
+        let ty = self.ty(rose::Ty::F64);
         let expr = rose::Expr::Unary {
             op: rose::Unop::Neg,
             arg: id::var(arg),
         };
-        self.instr(b, rose::Type::F64, expr)
+        self.instr(b, ty, expr)
     }
 
     #[wasm_bindgen]
     pub fn abs(&mut self, b: &mut Block, arg: usize) -> usize {
+        let ty = self.ty(rose::Ty::F64);
         let expr = rose::Expr::Unary {
             op: rose::Unop::Abs,
             arg: id::var(arg),
         };
-        self.instr(b, rose::Type::F64, expr)
+        self.instr(b, ty, expr)
     }
 
     #[wasm_bindgen]
     pub fn sqrt(&mut self, b: &mut Block, arg: usize) -> usize {
+        let ty = self.ty(rose::Ty::F64);
         let expr = rose::Expr::Unary {
             op: rose::Unop::Sqrt,
             arg: id::var(arg),
         };
-        self.instr(b, rose::Type::F64, expr)
+        self.instr(b, ty, expr)
     }
 
     // end of unary
@@ -466,157 +441,171 @@ impl Context {
 
     #[wasm_bindgen]
     pub fn and(&mut self, b: &mut Block, left: usize, right: usize) -> usize {
+        let ty = self.ty(rose::Ty::Bool);
         let expr = rose::Expr::Binary {
             op: rose::Binop::And,
             left: id::var(left),
             right: id::var(right),
         };
-        self.instr(b, rose::Type::Bool, expr)
+        self.instr(b, ty, expr)
     }
 
     #[wasm_bindgen]
     pub fn or(&mut self, b: &mut Block, left: usize, right: usize) -> usize {
+        let ty = self.ty(rose::Ty::Bool);
         let expr = rose::Expr::Binary {
             op: rose::Binop::Or,
             left: id::var(left),
             right: id::var(right),
         };
-        self.instr(b, rose::Type::Bool, expr)
+        self.instr(b, ty, expr)
     }
 
     #[wasm_bindgen]
     pub fn iff(&mut self, b: &mut Block, left: usize, right: usize) -> usize {
+        let ty = self.ty(rose::Ty::Bool);
         let expr = rose::Expr::Binary {
             op: rose::Binop::Iff,
             left: id::var(left),
             right: id::var(right),
         };
-        self.instr(b, rose::Type::Bool, expr)
+        self.instr(b, ty, expr)
     }
 
     #[wasm_bindgen]
     pub fn xor(&mut self, b: &mut Block, left: usize, right: usize) -> usize {
+        let ty = self.ty(rose::Ty::Bool);
         let expr = rose::Expr::Binary {
             op: rose::Binop::Xor,
             left: id::var(left),
             right: id::var(right),
         };
-        self.instr(b, rose::Type::Bool, expr)
+        self.instr(b, ty, expr)
     }
 
     #[wasm_bindgen]
     pub fn neq(&mut self, b: &mut Block, left: usize, right: usize) -> usize {
+        let ty = self.ty(rose::Ty::Bool);
         let expr = rose::Expr::Binary {
             op: rose::Binop::Neq,
             left: id::var(left),
             right: id::var(right),
         };
-        self.instr(b, rose::Type::Bool, expr)
+        self.instr(b, ty, expr)
     }
 
     #[wasm_bindgen]
     pub fn lt(&mut self, b: &mut Block, left: usize, right: usize) -> usize {
+        let ty = self.ty(rose::Ty::Bool);
         let expr = rose::Expr::Binary {
             op: rose::Binop::Lt,
             left: id::var(left),
             right: id::var(right),
         };
-        self.instr(b, rose::Type::Bool, expr)
+        self.instr(b, ty, expr)
     }
 
     #[wasm_bindgen]
     pub fn leq(&mut self, b: &mut Block, left: usize, right: usize) -> usize {
+        let ty = self.ty(rose::Ty::Bool);
         let expr = rose::Expr::Binary {
             op: rose::Binop::Leq,
             left: id::var(left),
             right: id::var(right),
         };
-        self.instr(b, rose::Type::Bool, expr)
+        self.instr(b, ty, expr)
     }
 
     #[wasm_bindgen]
     pub fn eq(&mut self, b: &mut Block, left: usize, right: usize) -> usize {
+        let ty = self.ty(rose::Ty::Bool);
         let expr = rose::Expr::Binary {
             op: rose::Binop::Eq,
             left: id::var(left),
             right: id::var(right),
         };
-        self.instr(b, rose::Type::Bool, expr)
+        self.instr(b, ty, expr)
     }
 
     #[wasm_bindgen]
     pub fn gt(&mut self, b: &mut Block, left: usize, right: usize) -> usize {
+        let ty = self.ty(rose::Ty::Bool);
         let expr = rose::Expr::Binary {
             op: rose::Binop::Gt,
             left: id::var(left),
             right: id::var(right),
         };
-        self.instr(b, rose::Type::Bool, expr)
+        self.instr(b, ty, expr)
     }
 
     #[wasm_bindgen]
     pub fn geq(&mut self, b: &mut Block, left: usize, right: usize) -> usize {
+        let ty = self.ty(rose::Ty::Bool);
         let expr = rose::Expr::Binary {
             op: rose::Binop::Geq,
             left: id::var(left),
             right: id::var(right),
         };
-        self.instr(b, rose::Type::Bool, expr)
+        self.instr(b, ty, expr)
     }
 
     #[wasm_bindgen]
     pub fn add(&mut self, b: &mut Block, left: usize, right: usize) -> usize {
+        let ty = self.ty(rose::Ty::F64);
         let expr = rose::Expr::Binary {
             op: rose::Binop::Add,
             left: id::var(left),
             right: id::var(right),
         };
-        self.instr(b, rose::Type::F64, expr)
+        self.instr(b, ty, expr)
     }
 
     #[wasm_bindgen]
     pub fn sub(&mut self, b: &mut Block, left: usize, right: usize) -> usize {
+        let ty = self.ty(rose::Ty::F64);
         let expr = rose::Expr::Binary {
             op: rose::Binop::Sub,
             left: id::var(left),
             right: id::var(right),
         };
-        self.instr(b, rose::Type::F64, expr)
+        self.instr(b, ty, expr)
     }
 
     #[wasm_bindgen]
     pub fn mul(&mut self, b: &mut Block, left: usize, right: usize) -> usize {
+        let ty = self.ty(rose::Ty::F64);
         let expr = rose::Expr::Binary {
             op: rose::Binop::Mul,
             left: id::var(left),
             right: id::var(right),
         };
-        self.instr(b, rose::Type::F64, expr)
+        self.instr(b, ty, expr)
     }
 
     #[wasm_bindgen]
     pub fn div(&mut self, b: &mut Block, left: usize, right: usize) -> usize {
+        let ty = self.ty(rose::Ty::F64);
         let expr = rose::Expr::Binary {
             op: rose::Binop::Div,
             left: id::var(left),
             right: id::var(right),
         };
-        self.instr(b, rose::Type::F64, expr)
+        self.instr(b, ty, expr)
     }
 
     // end of binary
 
     #[wasm_bindgen]
     pub fn call(&mut self, b: &mut Block, func: usize, arg: usize) -> Result<usize, JsError> {
-        let &t = self
-            .ret_types
+        let &(_, ty) = self
+            .funcs
             .get(func)
             .ok_or_else(|| JsError::new("invalid function ID"))?;
         let expr = rose::Expr::Call {
             func: id::func(func),
             arg: id::var(arg),
         };
-        Ok(self.instr(b, t, expr))
+        Ok(self.instr(b, ty, expr))
     }
 
     /// `rose::Expr::If`
@@ -632,41 +621,35 @@ impl Context {
     }
 
     // `rose::Expr::For`
-    fn arr(&mut self, b: &mut Block, index: rose::Type, body: usize) -> usize {
+    #[wasm_bindgen]
+    pub fn arr(&mut self, b: &mut Block, index: usize, body: usize) -> usize {
         let rose::Block { arg, ret, .. } = self.blocks[body];
-        let t = self.typexpr(rose::Typexpr::Array {
+        let ty = self.ty(rose::Ty::Array {
             index: self.get(arg),
             elem: self.get(ret),
         });
         let expr = rose::Expr::For {
-            index,
+            index: id::ty(index),
             body: id::block(body),
         };
-        self.instr(b, rose::Type::Expr { id: t }, expr)
-    }
-
-    #[wasm_bindgen(js_name = "forFin")]
-    pub fn for_fin(&mut self, b: &mut Block, size: usize, body: usize) -> usize {
-        self.arr(b, rose::Type::Fin { size }, body)
-    }
-
-    #[wasm_bindgen(js_name = "forGeneric")]
-    pub fn for_generic(&mut self, b: &mut Block, id: usize, body: usize) -> usize {
-        let index = rose::Type::Generic {
-            id: id::generic(id),
-        };
-        self.arr(b, index, body)
+        self.instr(b, ty, expr)
     }
 }
 
 /// Interpret a function with the given arguments.
 ///
-/// The `generics` are Serde-converted to `Vec<rose_interp::Typeval>`, the `arg` is Serde-converted
+/// The `types` are Serde-converted to `indexmap::IndexSet<rose::Ty>`, the `arg` is Serde-converted
 /// to `rose_interp::Val`, and the return value is Serde-converted from `rose_interp::Val`.
 #[wasm_bindgen]
-pub fn interp(f: &Func, generics: JsValue, arg: JsValue) -> Result<JsValue, JsError> {
-    let types: Vec<rose_interp::Typeval> = serde_wasm_bindgen::from_value(generics)?;
-    let val: rose_interp::Val = serde_wasm_bindgen::from_value(arg)?;
-    let ret = rose_interp::interp(f, &types, val)?;
+pub fn interp(
+    f: &Func,
+    types: JsValue,
+    generics: &[usize],
+    arg: JsValue,
+) -> Result<JsValue, JsError> {
+    let types: IndexSet<rose::Ty> = serde_wasm_bindgen::from_value(types)?;
+    let arg: rose_interp::Val = serde_wasm_bindgen::from_value(arg)?;
+    let generics: Vec<id::Ty> = generics.iter().map(|&i| id::ty(i)).collect();
+    let ret = rose_interp::interp(f, types, &generics, arg)?;
     Ok(to_js_value(&ret)?)
 }

--- a/packages/core/src/debug.test.ts
+++ b/packages/core/src/debug.test.ts
@@ -7,8 +7,7 @@ test("core IR type layouts", () => {
   expect(Object.fromEntries(wasm.layouts())).toEqual({
     Expr: { size: 16, align: 8 },
     Instr: { size: 24, align: 8 },
-    Type: { size: 8, align: 4 },
-    Typexpr: { size: 20, align: 4 },
+    Ty: { size: 16, align: 4 },
   });
 });
 
@@ -20,31 +19,45 @@ test("test rose to rust formatting", () => {
     `Function {
     generics: [],
     types: [
+        Bool,
+        F64,
         Tuple {
             members: [
-                F64,
-                F64,
+                Ty(
+                    1,
+                ),
+                Ty(
+                    1,
+                ),
             ],
         },
     ],
     funcs: [],
-    param: Expr {
-        id: Typexpr(
-            0,
-        ),
-    },
-    ret: F64,
+    param: Ty(
+        2,
+    ),
+    ret: Ty(
+        1,
+    ),
     vars: [
-        Expr {
-            id: Typexpr(
-                0,
-            ),
-        },
-        F64,
-        F64,
-        F64,
-        F64,
-        F64,
+        Ty(
+            2,
+        ),
+        Ty(
+            1,
+        ),
+        Ty(
+            1,
+        ),
+        Ty(
+            1,
+        ),
+        Ty(
+            1,
+        ),
+        Ty(
+            1,
+        ),
     ],
     blocks: [
         Block {

--- a/packages/core/src/ffi.ts
+++ b/packages/core/src/ffi.ts
@@ -1,6 +1,5 @@
 import * as wasm from "@rose-lang/wasm";
-import { Type } from "@rose-lang/wasm/core/Type";
-import { Typeval } from "@rose-lang/wasm/interp/Typeval";
+import { Ty } from "@rose-lang/wasm/core/Ty";
 import { Val } from "@rose-lang/wasm/interp/Val";
 
 /**
@@ -44,8 +43,13 @@ export interface Body {
   args: number[];
 }
 
-export const make = (generics: number, params: Type[], ret: Type): Body => {
-  const x = wasm.make(generics, params, ret);
+export const make = (
+  generics: number,
+  types: Ty[],
+  params: Uint32Array,
+  ret: number
+): Body => {
+  const x = wasm.make(generics, types, params, ret);
   try {
     return {
       ctx: x.ctx(),
@@ -58,8 +62,12 @@ export const make = (generics: number, params: Type[], ret: Type): Body => {
   }
 };
 
-export const interp = (f: Fn, generics: Typeval[], arg: Val): Val =>
-  wasm.interp(f.f, generics, arg);
+export const interp = (
+  f: Fn,
+  types: Ty[],
+  generics: Uint32Array,
+  arg: Val
+): Val => wasm.interp(f.f, types, generics, arg);
 
 export { Block, Context } from "@rose-lang/wasm";
-export type { Type, Typeval, Val };
+export type { Ty, Val };

--- a/packages/core/src/fn.ts
+++ b/packages/core/src/fn.ts
@@ -29,7 +29,7 @@ const call = (f: Fn, args: Val[]): Val => {
     b,
     new Uint32Array(args.map((arg) => getVar(ctx, b, arg)))
   );
-  const i = ctx.func(f.f.f, []);
+  const i = ctx.func(f.f.f, new Uint32Array());
   const y: Var = { ctx, id: ctx.call(b, i, x) };
   return y;
 };
@@ -44,15 +44,29 @@ type Args<T extends readonly Type[]> = {
   [K in keyof T]: Resolve<T[K]>;
 };
 
-const ffiType = (t: Type): ffi.Type => {
-  switch (t.tag) {
-    case "Bool": {
-      return "Bool";
+const makeSig = (
+  params: readonly Type[],
+  ret: Type
+): { types: ffi.Ty[]; params: Uint32Array; ret: number } => {
+  // TODO: support non-primitive types
+  const types: ffi.Ty[] = ["Bool", "F64"];
+
+  const ty = (t: Type): number => {
+    switch (t.tag) {
+      case "Bool": {
+        return types.indexOf("Bool");
+      }
+      case "Real": {
+        return types.indexOf("F64");
+      }
     }
-    case "Real": {
-      return "F64";
-    }
-  }
+  };
+
+  return {
+    types,
+    params: new Uint32Array(params.map(ty)),
+    ret: ty(ret),
+  };
 };
 
 /** Constructs an abstract function with the given `types` for parameters. */
@@ -65,10 +79,14 @@ export const fn = <const A extends readonly Type[], R extends Type>(
   // TODO: support closures
   if (context !== undefined)
     throw Error("can't define a function while defining another function");
-  const paramTypes = params.map(ffiType);
-  const retType = ffiType(ret);
+  const sig = makeSig(params, ret);
   let func: ffi.Fn;
-  const { ctx, main, arg, args: ids } = ffi.make(0, paramTypes, retType);
+  const {
+    ctx,
+    main,
+    arg,
+    args: ids,
+  } = ffi.make(0, sig.types, sig.params, sig.ret);
   try {
     setCtx(ctx);
     setBlock(main);

--- a/packages/core/src/interp.ts
+++ b/packages/core/src/interp.ts
@@ -34,6 +34,6 @@ export const interp =
   // just return a closure that calls the interpreter
   (...args: Args<A>) => {
     // TODO: support generics
-    const x = ffi.interp(f.f, [], { Tuple: args.map(pack) });
+    const x = ffi.interp(f.f, [], new Uint32Array(), { Tuple: args.map(pack) });
     return unpack(x) as Resolve<R>;
   };


### PR DESCRIPTION
Currently we have a whole bunch of ways to represent types:

- `rose::Type`
- `rose::Typexpr` (accompanied by `rose::id::Typexpr`)
- `rose::Typedef` (accompanied by `rose::id::Typedef`)
- `rose::TypeNode`
- `rose_interp::Typeval`

This PR replaces it all with just `rose::Ty` (accompanied by `rose::id::Ty`).

The `Typedef` and `TypeNode` stuff came from the idea that in order to do #34 we'd need to have our graph of objects include not just functions but also typedefs (which may include generics of their own), so that we can attach metadata about field names to those (for structs which we represent as tuples). But after doing more implementation work, it's become clear that most functions using these typedefs are going to need to pull in parts of their definitions into their own list of types, in order for their local variables to talk about the fields of those structs. The end result is just a lot of extra complexity added with no real memory usage benefit.

In contrast, when we remove typedefs (obviating #47), we now have the inductive property that, if the representations of two types in a function definition are equal, that is exactly equivalent to those types being compatible with each other in our type system, making #28 much easier. Of course this only works if we deduplicate types as we add them, for which purpose this PR pulls in the [`indexmap`](https://docs.rs/indexmap/2.0.0/indexmap/index.html) crate.

That covers the reason for the other bloat in representations: previously we were using `Type` vs `Typexpr` to distinguish "simple" from "more complicated" types, specifically in the sense that the latter were "type constructors" made up of smaller types, whereas the former were made up of other things but not types. It seemed silly to include many duplicates of primitive types like `Unit` and `Bool` in our list of defined types, so `Type` was [`Copy`](https://doc.rust-lang.org/std/marker/trait.Copy.html) to avoid that. But now we're deduplicating all types, not just primitives, so there's no need to separate these two categories. This eliminates more complexity in code that would have liked to treat all types the same, more of which was being added in #51 and #53.

One question which then comes up is, how _should_ we achieve #34? If we don't have `Typedef` and we're deduplicating types as we add them to a function definition, how can we attach metadata about field names? One way could be to define a new `enum` specifically for representing types in the `rose-web` crate, which distinguishes between tuples representing function argument lists and tuples representing structs; the latter would store field names, perhaps using [`Rc<str>`](https://doc.rust-lang.org/std/rc/struct.Rc.html#impl-From%3CString%3E-for-Rc%3Cstr%3E). Then storing those in an [`IndexSet`](https://docs.rs/indexmap/2.0.0/indexmap/set/struct.IndexSet.html) would only deduplicate at the semantic level of `rose-web`, and when we `bake` the final function, we can keep around any information about field names that we need for the function signature, and otherwise just map over our list of types and get rid of the field name info to construct actual Rose IR. In particular this means that when we write the validator, even if it deduplicates types as part of its checking routine, it should not enforce that the types are already deduplicated, because use cases like this show that sometimes it's more convenient not to deduplicate.