### PR TITLE
Use Node instead of curl

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,6 @@
 
 Make sure to have these tools installed:
 
-- [curl][]
 - [Git][]
 - [Make][]
 - [Rust][]
@@ -97,7 +96,6 @@ make vscode
 Then `packages/vscode` will contain a `*.vsix` file that you can install in VS
 Code by right-clicking it and clicking the **Install Extension VSIX** button.
 
-[curl]: https://curl.se/
 [git]: https://git-scm.com/downloads
 [make]: https://en.wikipedia.org/wiki/Make_(software)
 [node.js]: https://nodejs.org/en/download

--- a/Makefile
+++ b/Makefile
@@ -74,11 +74,11 @@ site: site-deps
 
 # fetch encircled icon
 packages/vscode/encircled-rose.png:
-	curl -O --output-dir packages/vscode https://github.com/rose-lang/rose-icons/raw/efcc218832d65970a47bed597ee11cecd3d1cc3c/png/encircled-rose.png
+	node fetch.js https://github.com/rose-lang/rose-icons/raw/efcc218832d65970a47bed597ee11cecd3d1cc3c/png/encircled-rose.png $@
 
 # fetch plain icon
 packages/vscode/plain-rose.png:
-	curl -O --output-dir packages/vscode https://github.com/rose-lang/rose-icons/raw/efcc218832d65970a47bed597ee11cecd3d1cc3c/png/plain-rose.png
+	node fetch.js https://github.com/rose-lang/rose-icons/raw/efcc218832d65970a47bed597ee11cecd3d1cc3c/png/plain-rose.png $@
 
 # build
 vscode: yarn packages/vscode/encircled-rose.png packages/vscode/plain-rose.png

--- a/fetch.js
+++ b/fetch.js
@@ -1,0 +1,24 @@
+import { createWriteStream } from "fs";
+import https from "https";
+import { pipeline } from "stream/promises";
+import { fileURLToPath } from "url";
+
+// extract command line arguments
+const [fileUrl, outputPath] = process.argv.slice(2);
+
+https
+  .get(fileUrl, async (response) => {
+    try {
+      await pipeline(
+        response,
+        createWriteStream(fileURLToPath(new URL(outputPath, import.meta.url)))
+      );
+    } catch (error) {
+      console.error(`Error fetching resource: ${error}`);
+      process.exit(1);
+    }
+  })
+  .on("error", (error) => {
+    console.error(`Error: ${error}`);
+    process.exit(1);
+  });


### PR DESCRIPTION
Following up on #17 and in the spirit of #57, this PR removes our dependency on curl by replacing our usages of it with a `fetch.js` script that I got ChatGPT to write.