### PR TITLE
Remove Node version range in `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,8 +6,8 @@ Make sure to have these tools installed:
 
 - [Git][]
 - [Make][]
+- [Node][]
 - [Rust][]
-- [Node.js][] v16-v18
 
 ## Setup
 
@@ -97,5 +97,5 @@ Code by right-clicking it and clicking the **Install Extension VSIX** button.
 
 [git]: https://git-scm.com/downloads
 [make]: https://en.wikipedia.org/wiki/Make_(software)
-[node.js]: https://nodejs.org/en/download
+[node]: https://nodejs.org/en/download
 [rust]: https://www.rust-lang.org/tools/install


### PR DESCRIPTION
From a conversation with @ravenrothkopf, it doesn't seem that we're actually constricted to this range (e.g. Node v20 should work). We can add this back if necessary.