### PR TITLE
Remove branching and nested `Ref`s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -661,6 +661,7 @@ dependencies = [
 name = "rose-interp"
 version = "0.0.0"
 dependencies = [
+ "enumset",
  "indexmap 2.0.0",
  "rose",
  "serde",

--- a/crates/core/src/id.rs
+++ b/crates/core/src/id.rs
@@ -86,26 +86,6 @@ impl Ty {
     }
 }
 
-/// Index of an instantiated function reference in a definition context.
-#[cfg_attr(test, derive(TS), ts(export))]
-#[cfg_attr(
-    feature = "serde",
-    derive(Serialize, Deserialize),
-    serde(rename = "FuncId")
-)]
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct Func(usize);
-
-pub fn func(id: usize) -> Func {
-    Func(id)
-}
-
-impl Func {
-    pub fn func(self) -> usize {
-        self.0
-    }
-}
-
 /// Index of a local variable in a function definition context.
 #[cfg_attr(test, derive(TS), ts(export))]
 #[cfg_attr(

--- a/crates/core/src/id.rs
+++ b/crates/core/src/id.rs
@@ -105,23 +105,3 @@ impl Var {
         self.0
     }
 }
-
-/// Index of a block in a function definition context.
-#[cfg_attr(test, derive(TS), ts(export))]
-#[cfg_attr(
-    feature = "serde",
-    derive(Serialize, Deserialize),
-    serde(rename = "BlockId")
-)]
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct Block(usize);
-
-pub fn block(id: usize) -> Block {
-    Block(id)
-}
-
-impl Block {
-    pub fn block(self) -> usize {
-        self.0
-    }
-}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -52,7 +52,7 @@ pub enum Ty {
         elem: id::Ty,
     },
     Tuple {
-        members: Vec<id::Ty>,
+        members: Vec<id::Ty>, // TODO: change to `Box<[id::Ty]`
     },
 }
 
@@ -60,19 +60,19 @@ pub enum Ty {
 #[derive(Debug)]
 pub struct Function {
     /// Generic type parameters.
-    pub generics: Vec<EnumSet<Constraint>>,
+    pub generics: Box<[EnumSet<Constraint>]>,
     /// Types used in this function definition.
-    pub types: Vec<Ty>,
+    pub types: Box<[Ty]>,
     /// Local variable types.
-    pub vars: Vec<id::Ty>,
+    pub vars: Box<[id::Ty]>,
     /// Parameter variables.
-    pub params: Vec<id::Var>,
+    pub params: Box<[id::Var]>,
     /// Return variable.
     pub ret: id::Var,
     /// Blocks of code.
-    pub blocks: Vec<Block>,
+    pub blocks: Box<[Block]>,
     /// Main block.
-    pub main: Vec<Instr>,
+    pub main: Box<[Instr]>,
 }
 
 /// Wrapper for a `Function` that knows how to resolve its `id::Function`s.
@@ -85,18 +85,18 @@ pub trait FuncNode {
         Self: Sized;
 }
 
-#[cfg_attr(test, derive(TS), ts(export))]
+// #[cfg_attr(test, derive(TS), ts(export))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub struct Block {
     /// Input variable to this block.
     pub arg: id::Var,
-    pub code: Vec<Instr>,
+    pub code: Box<[Instr]>,
     /// Output variable from this block.
     pub ret: id::Var,
 }
 
-#[cfg_attr(test, derive(TS), ts(export))]
+// #[cfg_attr(test, derive(TS), ts(export))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub struct Instr {
@@ -104,7 +104,7 @@ pub struct Instr {
     pub expr: Expr,
 }
 
-#[cfg_attr(test, derive(TS), ts(export))]
+// #[cfg_attr(test, derive(TS), ts(export))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub enum Expr {
@@ -120,10 +120,10 @@ pub enum Expr {
     },
 
     Array {
-        elems: Vec<id::Var>,
+        elems: Box<[id::Var]>,
     },
     Tuple {
-        members: Vec<id::Var>,
+        members: Box<[id::Var]>,
     },
 
     Index {
@@ -164,8 +164,8 @@ pub enum Expr {
 
     Call {
         id: id::Function,
-        generics: Vec<id::Ty>,
-        args: Vec<id::Var>,
+        generics: Box<[id::Ty]>,
+        args: Box<[id::Var]>,
     },
     For {
         /// Must satisfy `Constraint::Index`.

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -86,7 +86,6 @@ pub trait FuncNode {
         Self: Sized;
 }
 
-// #[cfg_attr(test, derive(TS), ts(export))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub struct Instr {
@@ -94,7 +93,6 @@ pub struct Instr {
     pub expr: Expr,
 }
 
-// #[cfg_attr(test, derive(TS), ts(export))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub enum Expr {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -13,6 +13,8 @@ use ts_rs::TS;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, EnumSetType)]
 pub enum Constraint {
+    /// Not a `Ref`.
+    Value,
     /// Can be the `index` type of an `Array`.
     Index,
     /// Allows a `Ref` to be read when used as its `scope` type.
@@ -59,6 +61,7 @@ pub enum Ty {
 pub struct Func {
     pub id: id::Function,
     pub generics: Vec<id::Ty>,
+    pub args: Vec<id::Var>,
 }
 
 /// A function definition.
@@ -68,18 +71,18 @@ pub struct Function {
     pub generics: Vec<EnumSet<Constraint>>,
     /// Types used in this function definition.
     pub types: Vec<Ty>,
-    /// Instantiations referenced functions with generic type parameters.
-    pub funcs: Vec<Func>,
-    /// Parameter type.
-    pub param: id::Ty,
-    /// Return type.
-    pub ret: id::Ty,
     /// Local variable types.
     pub vars: Vec<id::Ty>,
+    /// Calls to referenced functions.
+    pub funcs: Vec<Func>,
+    /// Parameter variables.
+    pub params: Vec<id::Var>,
+    /// Return variable.
+    pub ret: id::Var,
     /// Blocks of code.
     pub blocks: Vec<Block>,
     /// Main block.
-    pub main: id::Block,
+    pub main: Vec<Instr>,
 }
 
 /// Wrapper for a `Function` that knows how to resolve its `id::Function`s.
@@ -171,7 +174,6 @@ pub enum Expr {
 
     Call {
         func: id::Func,
-        arg: id::Var,
     },
     For {
         /// Must satisfy `Constraint::Index`.

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -56,14 +56,6 @@ pub enum Ty {
     },
 }
 
-/// Reference to a function, with types supplied for its generic parameters.
-#[derive(Debug)]
-pub struct Func {
-    pub id: id::Function,
-    pub generics: Vec<id::Ty>,
-    pub args: Vec<id::Var>,
-}
-
 /// A function definition.
 #[derive(Debug)]
 pub struct Function {
@@ -73,8 +65,6 @@ pub struct Function {
     pub types: Vec<Ty>,
     /// Local variable types.
     pub vars: Vec<id::Ty>,
-    /// Calls to referenced functions.
-    pub funcs: Vec<Func>,
     /// Parameter variables.
     pub params: Vec<id::Var>,
     /// Return variable.
@@ -173,7 +163,9 @@ pub enum Expr {
     },
 
     Call {
-        func: id::Func,
+        id: id::Function,
+        generics: Vec<id::Ty>,
+        args: Vec<id::Var>,
     },
     For {
         /// Must satisfy `Constraint::Index`.

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -130,7 +130,7 @@ pub enum Expr {
     Field {
         /// Must actually be a `Ref` of a tuple, not just a tuple.
         tuple: id::Var,
-        field: id::Member,
+        member: id::Member,
     },
 
     Unary {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -80,7 +80,6 @@ pub struct Function {
 pub trait FuncNode {
     fn def(&self) -> &Function;
 
-    /// Only valid with `id::Function`s from `self.def().funcs`.
     fn get(&self, id: id::Function) -> Option<Self>
     where
         Self: Sized;

--- a/crates/frontend/tests/interp.rs
+++ b/crates/frontend/tests/interp.rs
@@ -1,6 +1,6 @@
 use indexmap::IndexSet;
 use rose_frontend::parse;
-use rose_interp::{interp, val_f64, vals, Val};
+use rose_interp::{interp, val_f64};
 
 #[test]
 fn test_add() {
@@ -10,7 +10,7 @@ fn test_add() {
         module.get_func("add").unwrap(),
         IndexSet::new(),
         &[],
-        Val::Tuple(vals([val_f64(2.), val_f64(2.)])),
+        [val_f64(2.), val_f64(2.)].into_iter(),
     )
     .unwrap();
     assert_eq!(answer, val_f64(4.));
@@ -24,7 +24,7 @@ fn test_sub() {
         module.get_func("sub").unwrap(),
         IndexSet::new(),
         &[],
-        Val::Tuple(vals([val_f64(2.), val_f64(2.)])),
+        [val_f64(2.), val_f64(2.)].into_iter(),
     )
     .unwrap();
     assert_eq!(answer, val_f64(0.));

--- a/crates/frontend/tests/interp.rs
+++ b/crates/frontend/tests/interp.rs
@@ -1,7 +1,6 @@
 use indexmap::IndexSet;
 use rose_frontend::parse;
-use rose_interp::{interp, Val};
-use std::rc::Rc;
+use rose_interp::{interp, val_f64, vals, Val};
 
 #[test]
 fn test_add() {
@@ -11,10 +10,10 @@ fn test_add() {
         module.get_func("add").unwrap(),
         IndexSet::new(),
         &[],
-        Val::Tuple(Rc::new(vec![Val::F64(2.), Val::F64(2.)])),
+        Val::Tuple(vals([val_f64(2.), val_f64(2.)])),
     )
     .unwrap();
-    assert_eq!(answer, Val::F64(4.));
+    assert_eq!(answer, val_f64(4.));
 }
 
 #[test]
@@ -25,8 +24,8 @@ fn test_sub() {
         module.get_func("sub").unwrap(),
         IndexSet::new(),
         &[],
-        Val::Tuple(Rc::new(vec![Val::F64(2.), Val::F64(2.)])),
+        Val::Tuple(vals([val_f64(2.), val_f64(2.)])),
     )
     .unwrap();
-    assert_eq!(answer, Val::F64(0.));
+    assert_eq!(answer, val_f64(0.));
 }

--- a/crates/interp/Cargo.toml
+++ b/crates/interp/Cargo.toml
@@ -5,6 +5,7 @@ publish = false
 edition = "2021"
 
 [dependencies]
+enumset = "1"
 indexmap = "2"
 rose = { path = "../core" }
 serde = { version = "1", features = ["derive", "rc"], optional = true }

--- a/crates/interp/src/lib.rs
+++ b/crates/interp/src/lib.rs
@@ -181,8 +181,8 @@ impl<'a, F: FuncNode> Interpreter<'a, F> {
                 (Val::Array(v), &Val::Fin(i)) => v[i].clone(),
                 _ => unreachable!(),
             },
-            &Expr::Field { tuple, field } => match self.get(tuple).inner() {
-                Val::Tuple(x) => x[field.member()].clone(),
+            &Expr::Field { tuple, member } => match self.get(tuple).inner() {
+                Val::Tuple(x) => x[member.member()].clone(),
                 _ => unreachable!(),
             },
 

--- a/crates/interp/src/lib.rs
+++ b/crates/interp/src/lib.rs
@@ -224,12 +224,10 @@ impl<'a, F: FuncNode> Interpreter<'a, F> {
                 }
             }
 
-            &Expr::Call { func } => {
-                let f = &self.f.def().funcs[func.func()];
-                let generics: Vec<id::Ty> =
-                    f.generics.iter().map(|id| self.types[id.ty()]).collect();
-                let args = f.args.iter().map(|id| self.vars[id.var()].clone().unwrap());
-                call(self.f.get(f.id).unwrap(), self.typemap, &generics, args)
+            Expr::Call { id, generics, args } => {
+                let resolved: Vec<id::Ty> = generics.iter().map(|id| self.types[id.ty()]).collect();
+                let vals = args.iter().map(|id| self.vars[id.var()].clone().unwrap());
+                call(self.f.get(*id).unwrap(), self.typemap, &resolved, vals)
             }
             &Expr::For { index, body } => {
                 let n = match self.typemap[self.types[index.ty()].ty()] {
@@ -304,7 +302,7 @@ pub fn interp(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rose::{Func, Function, Instr};
+    use rose::{Function, Instr};
 
     #[derive(Clone, Copy, Debug)]
     struct FuncInSlice<'a> {
@@ -331,7 +329,6 @@ mod tests {
             generics: vec![],
             types: vec![Ty::F64],
             vars: vec![id::ty(0), id::ty(0), id::ty(0)],
-            funcs: vec![],
             params: vec![id::var(0), id::var(1)],
             ret: id::var(2),
             blocks: vec![],
@@ -364,7 +361,6 @@ mod tests {
                 generics: vec![],
                 types: vec![Ty::F64],
                 vars: vec![id::ty(0)],
-                funcs: vec![],
                 params: vec![],
                 ret: id::var(0),
                 blocks: vec![],
@@ -377,18 +373,17 @@ mod tests {
                 generics: vec![],
                 types: vec![Ty::F64],
                 vars: vec![id::ty(0), id::ty(0)],
-                funcs: vec![Func {
-                    id: id::function(0),
-                    generics: vec![],
-                    args: vec![],
-                }],
                 params: vec![],
                 ret: id::var(1),
                 blocks: vec![],
                 main: vec![
                     Instr {
                         var: id::var(0),
-                        expr: Expr::Call { func: id::func(0) },
+                        expr: Expr::Call {
+                            id: id::function(0),
+                            generics: vec![],
+                            args: vec![],
+                        },
                     },
                     Instr {
                         var: id::var(1),

--- a/crates/interp/src/lib.rs
+++ b/crates/interp/src/lib.rs
@@ -14,11 +14,25 @@ use ts_rs::TS;
 pub enum Val {
     Unit,
     Bool(bool),
-    F64(f64),
+    F64(Cell<f64>),
     Fin(usize),
-    Ref(Rc<Cell<f64>>),
-    Array(Rc<Vec<Val>>), // assume all indices are `Fin`
-    Tuple(Rc<Vec<Val>>),
+    Ref(Rc<Val>),
+    Array(Vals), // assume all indices are `Fin`
+    Tuple(Vals),
+}
+
+pub type Vals = Rc<Vec<Val>>; // TODO: change to `Rc<[Val]>` https://github.com/rose-lang/rose/issues/63
+
+pub fn vals<const N: usize>(v: [Val; N]) -> Vals {
+    Rc::new(v.to_vec())
+}
+
+pub fn collect_vals(it: impl Iterator<Item = Val>) -> Vals {
+    Rc::new(it.collect())
+}
+
+pub fn val_f64(x: f64) -> Val {
+    Val::F64(Cell::new(x))
 }
 
 impl Val {
@@ -31,29 +45,39 @@ impl Val {
 
     fn f64(&self) -> f64 {
         match self {
-            &Val::F64(x) => x,
+            Val::F64(x) => x.get(),
             _ => unreachable!(),
         }
     }
-}
 
-impl Val {
-    /// Pull out the immutable inner value represented by this mutable `Ref` type.
-    fn immut(&self) -> Self {
+    fn inner(&self) -> &Self {
         match self {
-            Self::Ref(x) => Self::F64(x.get()),
-            Self::Array(x) => Self::Array(Rc::new(x.iter().map(|x| x.immut()).collect())),
-            Self::Tuple(x) => Self::Tuple(Rc::new(x.iter().map(|x| x.immut()).collect())),
-            Self::Unit | Self::Bool(..) | Self::F64(..) | Self::Fin { .. } => {
-                unreachable!()
-            }
+            Val::Ref(x) => x.as_ref(),
+            _ => unreachable!(),
+        }
+    }
+
+    /// Return a zero value with this value's topology.
+    fn zero(&self) -> Self {
+        match self {
+            Self::Unit => Self::Unit,
+            &Self::Bool(x) => Self::Bool(x),
+            Self::F64(_) => Self::F64(Cell::new(0.)),
+            &Self::Fin(x) => Self::Fin(x),
+            Self::Ref(x) => Self::Ref(Rc::clone(x)),
+            Self::Array(x) => Self::Array(collect_vals(x.iter().map(|x| x.zero()))),
+            Self::Tuple(x) => Self::Tuple(collect_vals(x.iter().map(|x| x.zero()))),
         }
     }
 
     /// Add `x` to this value, which must represent a mutable `Ref` type.
     fn add(&self, x: &Self) {
         match (self, x) {
-            (Self::Ref(a), Self::F64(b)) => a.set(a.get() + b),
+            (Self::Unit, Self::Unit)
+            | (Self::Bool(_), Self::Bool(_))
+            | (Self::Fin(_), Self::Fin(_))
+            | (Self::Ref(_), Self::Ref(_)) => {}
+            (Self::F64(a), Self::F64(b)) => a.set(a.get() + b.get()),
             (Self::Array(a), Self::Array(b)) => {
                 for (a, b) in a.iter().zip(b.iter()) {
                     a.add(b);
@@ -66,26 +90,6 @@ impl Val {
             }
             _ => unreachable!(),
         }
-    }
-}
-
-/// Return zero a value of `Ref` type for this type, which must satisfy `Constraint::Vector`.
-fn zero(types: &IndexSet<Ty>, ty: id::Ty) -> Val {
-    match &types[ty.ty()] {
-        Ty::F64 => Val::Ref(Rc::new(Cell::new(0.))),
-        &Ty::Array { index, elem } => match types[index.ty()] {
-            Ty::Fin { size } => Val::Array(Rc::new((0..size).map(|_| zero(types, elem)).collect())),
-            _ => unreachable!(),
-        },
-        Ty::Tuple { members } => {
-            Val::Tuple(Rc::new(members.iter().map(|&x| zero(types, x)).collect()))
-        }
-        Ty::Unit
-        | Ty::Bool
-        | Ty::Fin { .. }
-        | Ty::Generic { .. }
-        | Ty::Scope { .. }
-        | Ty::Ref { .. } => unreachable!(),
     }
 }
 
@@ -152,15 +156,15 @@ impl<'a, F: FuncNode> Interpreter<'a, F> {
         match expr {
             Expr::Unit => Val::Unit,
             &Expr::Bool { val } => Val::Bool(val),
-            &Expr::F64 { val } => Val::F64(val),
+            &Expr::F64 { val } => val_f64(val),
             &Expr::Fin { val } => Val::Fin(val),
 
-            Expr::Array { elems } => Val::Array(Rc::new(
-                elems.iter().map(|&x| self.get(x).clone()).collect(),
-            )),
-            Expr::Tuple { members } => Val::Tuple(Rc::new(
-                members.iter().map(|&x| self.get(x).clone()).collect(),
-            )),
+            Expr::Array { elems } => {
+                Val::Array(collect_vals(elems.iter().map(|&x| self.get(x).clone())))
+            }
+            Expr::Tuple { members } => {
+                Val::Tuple(collect_vals(members.iter().map(|&x| self.get(x).clone())))
+            }
 
             &Expr::Index { array, index } => match (self.get(array), self.get(index)) {
                 (Val::Array(v), &Val::Fin(i)) => v[i].clone(),
@@ -171,12 +175,11 @@ impl<'a, F: FuncNode> Interpreter<'a, F> {
                 _ => unreachable!(),
             },
 
-            // a `Ref` of `F64` becomes `Ref`, while composites just wrap those individual refs
-            &Expr::Slice { array, index } => match (self.get(array), self.get(index)) {
+            &Expr::Slice { array, index } => match (self.get(array).inner(), self.get(index)) {
                 (Val::Array(v), &Val::Fin(i)) => v[i].clone(),
                 _ => unreachable!(),
             },
-            &Expr::Field { tuple, field } => match self.get(tuple) {
+            &Expr::Field { tuple, field } => match self.get(tuple).inner() {
                 Val::Tuple(x) => x[field.member()].clone(),
                 _ => unreachable!(),
             },
@@ -186,9 +189,9 @@ impl<'a, F: FuncNode> Interpreter<'a, F> {
                 match op {
                     Unop::Not => Val::Bool(!x.bool()),
 
-                    Unop::Neg => Val::F64(-x.f64()),
-                    Unop::Abs => Val::F64(x.f64().abs()),
-                    Unop::Sqrt => Val::F64(x.f64().sqrt()),
+                    Unop::Neg => val_f64(-x.f64()),
+                    Unop::Abs => val_f64(x.f64().abs()),
+                    Unop::Sqrt => val_f64(x.f64().sqrt()),
                 }
             }
             &Expr::Binary { op, left, right } => {
@@ -207,10 +210,17 @@ impl<'a, F: FuncNode> Interpreter<'a, F> {
                     Binop::Gt => Val::Bool(x.f64() > y.f64()),
                     Binop::Geq => Val::Bool(x.f64() >= y.f64()),
 
-                    Binop::Add => Val::F64(x.f64() + y.f64()),
-                    Binop::Sub => Val::F64(x.f64() - y.f64()),
-                    Binop::Mul => Val::F64(x.f64() * y.f64()),
-                    Binop::Div => Val::F64(x.f64() / y.f64()),
+                    Binop::Add => val_f64(x.f64() + y.f64()),
+                    Binop::Sub => val_f64(x.f64() - y.f64()),
+                    Binop::Mul => val_f64(x.f64() * y.f64()),
+                    Binop::Div => val_f64(x.f64() / y.f64()),
+                }
+            }
+            &Expr::Select { cond, then, els } => {
+                if self.get(cond).bool() {
+                    self.get(then).clone()
+                } else {
+                    self.get(els).clone()
                 }
             }
 
@@ -225,32 +235,30 @@ impl<'a, F: FuncNode> Interpreter<'a, F> {
                     self.get(arg).clone(),
                 )
             }
-            &Expr::If { cond, then, els } => {
-                if self.get(cond).bool() {
-                    self.block(then, Val::Unit).clone()
-                } else {
-                    self.block(els, Val::Unit).clone()
-                }
-            }
             &Expr::For { index, body } => {
                 let n = match self.typemap[self.types[index.ty()].ty()] {
                     Ty::Fin { size } => size,
                     _ => unreachable!(),
                 };
-                let v: Vec<Val> = (0..n)
-                    .map(|i| self.block(body, Val::Fin(i)).clone())
-                    .collect();
-                Val::Array(Rc::new(v))
+                Val::Array(collect_vals(
+                    (0..n).map(|i| self.block(body, Val::Fin(i)).clone()),
+                ))
             }
-            &Expr::Accum { var, vector, body } => {
-                let x = zero(self.typemap, self.types[vector.ty()]);
+            &Expr::Read { var, body } => {
+                let r = Val::Ref(Rc::new(self.get(var).clone()));
+                let x = self.block(body, r).clone();
+                x
+            }
+            &Expr::Accum { var, shape, body } => {
+                let x = Val::Ref(Rc::new(self.get(shape).zero()));
                 let y = self.block(body, x.clone()).clone();
-                self.vars[var.var()] = Some(x.immut());
+                self.vars[var.var()] = Some(x.inner().clone());
                 y
             }
 
+            &Expr::Ask { var } => self.get(var).inner().clone(),
             &Expr::Add { accum, addend } => {
-                self.get(accum).add(self.get(addend));
+                self.get(accum).inner().add(self.get(addend));
                 Val::Unit
             }
         }
@@ -362,10 +370,10 @@ mod tests {
             },
             IndexSet::new(),
             &[],
-            Val::Tuple(Rc::new(vec![Val::F64(2.), Val::F64(2.)])),
+            Val::Tuple(vals([val_f64(2.), val_f64(2.)])),
         )
         .unwrap();
-        assert_eq!(answer, Val::F64(4.));
+        assert_eq!(answer, val_f64(4.));
     }
 
     #[test]
@@ -432,6 +440,126 @@ mod tests {
             Val::Unit,
         )
         .unwrap();
-        assert_eq!(answer, Val::F64(1764.));
+        assert_eq!(answer, val_f64(1764.));
+    }
+
+    #[test]
+    fn test_nested_ref() {
+        let funcs = vec![Function {
+            generics: vec![],
+            types: vec![
+                Ty::Unit,
+                Ty::F64,
+                Ty::Scope { id: id::block(1) },
+                Ty::Ref {
+                    scope: id::ty(2),
+                    inner: id::ty(1),
+                },
+                Ty::Tuple {
+                    members: vec![id::ty(1), id::ty(3)],
+                },
+                Ty::Scope { id: id::block(2) },
+                Ty::Ref {
+                    scope: id::ty(5),
+                    inner: id::ty(4),
+                },
+                Ty::Tuple {
+                    members: vec![id::ty(1), id::ty(1)],
+                },
+            ],
+            funcs: vec![],
+            param: id::ty(0),
+            ret: id::ty(7),
+            vars: vec![
+                id::ty(0),
+                id::ty(1),
+                id::ty(1),
+                id::ty(1),
+                id::ty(7),
+                id::ty(3),
+                id::ty(4),
+                id::ty(0),
+                id::ty(4),
+                id::ty(1),
+                id::ty(6),
+                id::ty(0),
+            ],
+            blocks: vec![
+                Block {
+                    arg: id::var(0),
+                    code: vec![
+                        Instr {
+                            var: id::var(1),
+                            expr: Expr::F64 { val: 42. },
+                        },
+                        Instr {
+                            var: id::var(2),
+                            expr: Expr::Accum {
+                                var: id::var(3),
+                                shape: id::var(1),
+                                body: id::block(1),
+                            },
+                        },
+                        Instr {
+                            var: id::var(4),
+                            expr: Expr::Tuple {
+                                members: vec![id::var(2), id::var(3)],
+                            },
+                        },
+                    ],
+                    ret: id::var(4),
+                },
+                Block {
+                    arg: id::var(5),
+                    code: vec![
+                        Instr {
+                            var: id::var(6),
+                            expr: Expr::Tuple {
+                                members: vec![id::var(1), id::var(5)],
+                            },
+                        },
+                        Instr {
+                            var: id::var(7),
+                            expr: Expr::Accum {
+                                var: id::var(8),
+                                shape: id::var(6),
+                                body: id::block(2),
+                            },
+                        },
+                        Instr {
+                            var: id::var(9),
+                            expr: Expr::Member {
+                                tuple: id::var(8),
+                                member: id::member(0),
+                            },
+                        },
+                    ],
+                    ret: id::var(9),
+                },
+                Block {
+                    arg: id::var(10),
+                    code: vec![Instr {
+                        var: id::var(11),
+                        expr: Expr::Add {
+                            accum: id::var(10),
+                            addend: id::var(6),
+                        },
+                    }],
+                    ret: id::var(11),
+                },
+            ],
+            main: id::block(0), // TODO
+        }];
+        let answer = interp(
+            FuncInSlice {
+                funcs: &funcs,
+                id: id::function(0),
+            },
+            IndexSet::new(),
+            &[],
+            Val::Unit,
+        )
+        .unwrap();
+        assert_eq!(answer, Val::Tuple(vals([val_f64(42.), val_f64(0.)])));
     }
 }

--- a/crates/interp/src/lib.rs
+++ b/crates/interp/src/lib.rs
@@ -64,7 +64,7 @@ impl Val {
             &Self::Bool(x) => Self::Bool(x),
             Self::F64(_) => Self::F64(Cell::new(0.)),
             &Self::Fin(x) => Self::Fin(x),
-            Self::Ref(x) => Self::Ref(Rc::clone(x)),
+            Self::Ref(_) => unreachable!(),
             Self::Array(x) => Self::Array(collect_vals(x.iter().map(|x| x.zero()))),
             Self::Tuple(x) => Self::Tuple(collect_vals(x.iter().map(|x| x.zero()))),
         }
@@ -75,8 +75,7 @@ impl Val {
         match (self, x) {
             (Self::Unit, Self::Unit)
             | (Self::Bool(_), Self::Bool(_))
-            | (Self::Fin(_), Self::Fin(_))
-            | (Self::Ref(_), Self::Ref(_)) => {}
+            | (Self::Fin(_), Self::Fin(_)) => {}
             (Self::F64(a), Self::F64(b)) => a.set(a.get() + b.get()),
             (Self::Array(a), Self::Array(b)) => {
                 for (a, b) in a.iter().zip(b.iter()) {

--- a/crates/interp/src/lib.rs
+++ b/crates/interp/src/lib.rs
@@ -137,7 +137,7 @@ struct Interpreter<'a, F: FuncNode> {
 impl<'a, F: FuncNode> Interpreter<'a, F> {
     fn new(typemap: &'a mut IndexSet<Ty>, f: &'a F, generics: &'a [id::Ty]) -> Self {
         let mut types = vec![];
-        for ty in &f.def().types {
+        for ty in f.def().types.iter() {
             types.push(resolve(typemap, generics, &types, ty));
         }
         Self {
@@ -261,7 +261,7 @@ impl<'a, F: FuncNode> Interpreter<'a, F> {
     fn block(&mut self, b: id::Block, arg: Val) -> &Val {
         let block = &self.f.def().blocks[b.block()];
         self.vars[block.arg.var()] = Some(arg);
-        for instr in &block.code {
+        for instr in block.code.iter() {
             self.vars[instr.var.var()] = Some(self.expr(&instr.expr));
         }
         self.vars[block.ret.var()].as_ref().unwrap()
@@ -279,7 +279,7 @@ fn call(
     for (var, arg) in f.def().params.iter().zip(args) {
         interp.vars[var.var()] = Some(arg.clone());
     }
-    for instr in &f.def().main {
+    for instr in f.def().main.iter() {
         interp.vars[instr.var.var()] = Some(interp.expr(&instr.expr));
     }
     interp.vars[f.def().ret.var()].as_ref().unwrap().clone()
@@ -326,12 +326,12 @@ mod tests {
     #[test]
     fn test_two_plus_two() {
         let funcs = vec![Function {
-            generics: vec![],
-            types: vec![Ty::F64],
-            vars: vec![id::ty(0), id::ty(0), id::ty(0)],
-            params: vec![id::var(0), id::var(1)],
+            generics: vec![].into(),
+            types: vec![Ty::F64].into(),
+            vars: vec![id::ty(0), id::ty(0), id::ty(0)].into(),
+            params: vec![id::var(0), id::var(1)].into(),
             ret: id::var(2),
-            blocks: vec![],
+            blocks: vec![].into(),
             main: vec![Instr {
                 var: id::var(2),
                 expr: Expr::Binary {
@@ -339,7 +339,8 @@ mod tests {
                     left: id::var(0),
                     right: id::var(1),
                 },
-            }],
+            }]
+            .into(),
         }];
         let answer = interp(
             FuncInSlice {
@@ -358,31 +359,32 @@ mod tests {
     fn test_nested_call() {
         let funcs = vec![
             Function {
-                generics: vec![],
-                types: vec![Ty::F64],
-                vars: vec![id::ty(0)],
-                params: vec![],
+                generics: vec![].into(),
+                types: vec![Ty::F64].into(),
+                vars: vec![id::ty(0)].into(),
+                params: vec![].into(),
                 ret: id::var(0),
-                blocks: vec![],
+                blocks: vec![].into(),
                 main: vec![Instr {
                     var: id::var(0),
                     expr: Expr::F64 { val: 42. },
-                }],
+                }]
+                .into(),
             },
             Function {
-                generics: vec![],
-                types: vec![Ty::F64],
-                vars: vec![id::ty(0), id::ty(0)],
-                params: vec![],
+                generics: vec![].into(),
+                types: vec![Ty::F64].into(),
+                vars: vec![id::ty(0), id::ty(0)].into(),
+                params: vec![].into(),
                 ret: id::var(1),
-                blocks: vec![],
+                blocks: vec![].into(),
                 main: vec![
                     Instr {
                         var: id::var(0),
                         expr: Expr::Call {
                             id: id::function(0),
-                            generics: vec![],
-                            args: vec![],
+                            generics: vec![].into(),
+                            args: vec![].into(),
                         },
                     },
                     Instr {
@@ -393,7 +395,8 @@ mod tests {
                             right: id::var(0),
                         },
                     },
-                ],
+                ]
+                .into(),
             },
         ];
         let answer = interp(

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -99,8 +99,8 @@ pub fn pprint(f: &Func) -> Result<String, JsError> {
             rose::Expr::Slice { array, index } => {
                 writeln!(&mut s, "x{}![x{}]", array.var(), index.var())?
             }
-            rose::Expr::Field { tuple, field } => {
-                writeln!(&mut s, "x{}!.{}", tuple.var(), field.member())?
+            rose::Expr::Field { tuple, member } => {
+                writeln!(&mut s, "x{}!.{}", tuple.var(), member.member())?
             }
             rose::Expr::Unary { op, arg } => match op {
                 rose::Unop::Not => writeln!(&mut s, "not x{}", arg.var())?,

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -34,6 +34,7 @@ pub fn layouts() -> Result<JsValue, serde_wasm_bindgen::Error> {
 
     to_js_value(&[
         ("Expr", layout::<rose::Expr>()),
+        ("Function", layout::<rose::Function>()),
         ("Instr", layout::<rose::Instr>()),
         ("Ty", layout::<rose::Ty>()),
     ])

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -608,14 +608,15 @@ impl Context {
         Ok(self.instr(b, ty, expr))
     }
 
-    /// `rose::Expr::If`
     #[wasm_bindgen]
-    pub fn cond(&mut self, b: &mut Block, cond: usize, then: usize, els: usize) -> usize {
-        let t = self.get(self.blocks[then].ret); // arbitrary; could have used `els` instead
-        let expr = rose::Expr::If {
+    pub fn select(&mut self, b: &mut Block, cond: usize, then: usize, els: usize) -> usize {
+        let then = id::var(then);
+        let els = id::var(els);
+        let t = self.get(then); // arbitrary; could have used `els` instead
+        let expr = rose::Expr::Select {
             cond: id::var(cond),
-            then: id::block(then),
-            els: id::block(els),
+            then,
+            els,
         };
         self.instr(b, t, expr)
     }

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -294,13 +294,13 @@ pub fn bake(ctx: Context, out: usize, main: Block) -> Func {
         rc: Rc::new((
             functions,
             rose::Function {
-                generics,
+                generics: generics.into(),
                 types: types.into_iter().collect(),
-                params,
+                params: params.into(),
                 ret: id::var(out),
-                vars,
-                blocks,
-                main: main.code,
+                vars: vars.into(),
+                blocks: blocks.into(),
+                main: main.code.into(),
             },
         )),
     }
@@ -423,7 +423,7 @@ impl Context {
         let id = self.blocks.len();
         self.blocks.push(rose::Block {
             arg: id::var(arg_id),
-            code,
+            code: code.into(),
             ret: id::var(ret_id),
         });
         id
@@ -490,7 +490,7 @@ impl Context {
             index,
             elem: self.get(x),
         });
-        let expr = rose::Expr::Array { elems: xs };
+        let expr = rose::Expr::Array { elems: xs.into() };
         Ok(self.instr(b, ty, expr))
     }
 
@@ -499,7 +499,7 @@ impl Context {
         let xs: Vec<id::Var> = members.iter().map(|&x| id::var(x)).collect();
         let types = xs.iter().map(|&x| self.get(x)).collect();
         let ty = self.ty(rose::Ty::Tuple { members: types });
-        let expr = rose::Expr::Tuple { members: xs };
+        let expr = rose::Expr::Tuple { members: xs.into() };
         self.instr(b, ty, expr)
     }
 
@@ -740,7 +740,7 @@ impl Context {
         let mut types = vec![];
         let (_, def) = f.rc.as_ref();
         // push a corresponding type onto our own `types` for each type in the callee
-        for callee_type in &def.types {
+        for callee_type in def.types.iter() {
             types.push(resolve(&mut self.types, generics, &types, callee_type));
         }
 

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -124,31 +124,11 @@ pub fn pprint(f: &Func) -> Result<String, JsError> {
                     rose::Binop::Mul => writeln!(&mut s, "x{} * x{}", left.var(), right.var())?,
                     rose::Binop::Div => writeln!(&mut s, "x{} / x{}", left.var(), right.var())?,
                 },
+                rose::Expr::Select { cond, then, els } => {
+                    writeln!(&mut s, "x{} ? x{} : x{}", cond.var(), then.var(), els.var())?
+                }
                 rose::Expr::Call { func, arg } => {
                     writeln!(&mut s, "f{}(x{})", func.func(), arg.var())?
-                }
-                rose::Expr::If { cond, then, els } => {
-                    writeln!(&mut s, "if x{} {{", cond.var())?;
-                    for _ in 0..spaces {
-                        write!(&mut s, " ")?;
-                    }
-                    let x = def.blocks[then.block()].arg.var();
-                    writeln!(&mut s, "  x{x}: T{}", def.vars[x].ty())?;
-                    print_block(s, def, spaces + 2, *then)?;
-                    for _ in 0..spaces {
-                        write!(&mut s, " ")?;
-                    }
-                    writeln!(&mut s, "}} else {{")?;
-                    for _ in 0..spaces {
-                        write!(&mut s, " ")?;
-                    }
-                    let y = def.blocks[els.block()].arg.var();
-                    writeln!(&mut s, "  x{y}: T{}", def.vars[y].ty())?;
-                    print_block(s, def, spaces + 2, *els)?;
-                    for _ in 0..spaces {
-                        write!(&mut s, " ")?;
-                    }
-                    writeln!(&mut s, "}}")?
                 }
                 rose::Expr::For { index, body } => {
                     writeln!(
@@ -163,8 +143,8 @@ pub fn pprint(f: &Func) -> Result<String, JsError> {
                     }
                     writeln!(&mut s, "}}")?
                 }
-                rose::Expr::Accum { var, vector, body } => {
-                    writeln!(&mut s, "accum x{}: T{} {{", var.var(), vector.ty())?;
+                rose::Expr::Read { var, body } => {
+                    writeln!(&mut s, "read x{} {{", var.var())?;
                     for _ in 0..spaces {
                         write!(&mut s, " ")?;
                     }
@@ -176,6 +156,20 @@ pub fn pprint(f: &Func) -> Result<String, JsError> {
                     }
                     writeln!(&mut s, "}}")?
                 }
+                rose::Expr::Accum { var, shape, body } => {
+                    writeln!(&mut s, "accum x{} from x{} {{", var.var(), shape.var())?;
+                    for _ in 0..spaces {
+                        write!(&mut s, " ")?;
+                    }
+                    let x = def.blocks[body.block()].arg.var();
+                    writeln!(&mut s, "  x{x}: T{}", def.vars[x].ty())?;
+                    print_block(s, def, spaces + 2, *body)?;
+                    for _ in 0..spaces {
+                        write!(&mut s, " ")?;
+                    }
+                    writeln!(&mut s, "}}")?
+                }
+                rose::Expr::Ask { var } => writeln!(&mut s, "ask x{}", var.var())?,
                 rose::Expr::Add { accum, addend } => {
                     writeln!(&mut s, "x{} += x{}", accum.var(), addend.var())?
                 }

--- a/packages/core/src/bool.ts
+++ b/packages/core/src/bool.ts
@@ -1,5 +1,4 @@
-import { Val, Var, getBlock, getCtx, getVar, setBlock } from "./context.js";
-import * as ffi from "./ffi.js";
+import { Val, Var, getBlock, getCtx, getVar } from "./context.js";
 
 export type Bool = boolean | Var;
 
@@ -33,43 +32,11 @@ export const xor = (p: Bool, q: Bool): Bool => {
   return { ctx, id: ctx.xor(b, getVar(ctx, b, p), getVar(ctx, b, q)) };
 };
 
-export const cond = <T extends Val>(
-  cond: Bool,
-  then: () => T,
-  els: () => T,
-): T | Var => {
+export const select = <T extends Val>(cond: Bool, then: T, els: T): T | Var => {
   const ctx = getCtx();
   const b = getBlock();
-
   const p = getVar(ctx, b, cond);
-
-  const at = ctx.varUnit(); // `then` and `els` blocks take in `Unit`-type arg
-  const bt = new ffi.Block();
-  let nt: number; // block ID
-  try {
-    setBlock(bt);
-    const rt = getVar(ctx, bt, then());
-    nt = ctx.block(bt, at, rt);
-  } catch (e) {
-    bt.free();
-    throw e;
-  } finally {
-    setBlock(b);
-  }
-
-  const af = ctx.varUnit();
-  const bf = new ffi.Block();
-  let nf: number;
-  try {
-    setBlock(bf);
-    const rf = getVar(ctx, bf, els());
-    nf = ctx.block(bf, af, rf);
-  } catch (e) {
-    bf.free();
-    throw e;
-  } finally {
-    setBlock(b);
-  }
-
-  return { ctx, id: ctx.cond(b, p, nt, nf) };
+  const t = getVar(ctx, b, then);
+  const e = getVar(ctx, b, els);
+  return { ctx, id: ctx.select(b, p, t, e) };
 };

--- a/packages/core/src/debug.test.ts
+++ b/packages/core/src/debug.test.ts
@@ -28,8 +28,8 @@ import {
 test("core IR type layouts", () => {
   // these don't matter too much, but it's good to notice if sizes increase
   expect(Object.fromEntries(wasm.layouts())).toEqual({
-    Expr: { size: 32, align: 8 },
-    Instr: { size: 40, align: 8 },
+    Expr: { size: 24, align: 8 },
+    Instr: { size: 32, align: 8 },
     Ty: { size: 16, align: 4 },
   });
 });

--- a/packages/core/src/debug.test.ts
+++ b/packages/core/src/debug.test.ts
@@ -29,6 +29,7 @@ test("core IR type layouts", () => {
   // these don't matter too much, but it's good to notice if sizes increase
   expect(Object.fromEntries(wasm.layouts())).toEqual({
     Expr: { size: 24, align: 8 },
+    Function: { size: 44, align: 4 },
     Instr: { size: 32, align: 8 },
     Ty: { size: 16, align: 4 },
   });

--- a/packages/core/src/debug.test.ts
+++ b/packages/core/src/debug.test.ts
@@ -6,7 +6,6 @@ import {
   abs,
   add,
   and,
-  cond,
   div,
   eq,
   fn,
@@ -20,6 +19,7 @@ import {
   neq,
   not,
   or,
+  select,
   sqrt,
   sub,
   xor,
@@ -38,17 +38,9 @@ describe("pprint", () => {
   test("if", () => {
     const f = fn([Real, Real], Real, (x, y) => {
       const p = lt(x, y);
-      const z = cond(
-        p,
-        () => {
-          const a = mul(x, y);
-          return add(a, x);
-        },
-        () => {
-          const b = sub(y, x);
-          return mul(b, y);
-        },
-      );
+      const a = mul(x, y);
+      const b = sub(y, x);
+      const z = select(p, add(a, x), mul(b, y));
       const w = add(z, x);
       return add(y, w);
     });
@@ -58,25 +50,18 @@ describe("pprint", () => {
 T0 = Bool
 T1 = F64
 T2 = (T1, T1)
-T3 = Unit
 x0: T2 -> T1 {
   x1: T1 = x0.0
   x2: T1 = x0.1
   x3: T0 = x1 < x2
-  x10: T1 = if x3 {
-    x4: T3
-    x5: T1 = x1 * x2
-    x6: T1 = x5 + x1
-    x6
-  } else {
-    x7: T3
-    x8: T1 = x2 - x1
-    x9: T1 = x8 * x2
-    x9
-  }
-  x11: T1 = x10 + x1
-  x12: T1 = x2 + x11
-  x12
+  x4: T1 = x1 * x2
+  x5: T1 = x2 - x1
+  x6: T1 = x4 + x1
+  x7: T1 = x5 * x2
+  x8: T1 = x3 ? x6 : x7
+  x9: T1 = x8 + x1
+  x10: T1 = x2 + x9
+  x10
 }
 `.trimStart(),
     );

--- a/packages/core/src/debug.test.ts
+++ b/packages/core/src/debug.test.ts
@@ -28,8 +28,8 @@ import {
 test("core IR type layouts", () => {
   // these don't matter too much, but it's good to notice if sizes increase
   expect(Object.fromEntries(wasm.layouts())).toEqual({
-    Expr: { size: 16, align: 8 },
-    Instr: { size: 24, align: 8 },
+    Expr: { size: 32, align: 8 },
+    Instr: { size: 40, align: 8 },
     Ty: { size: 16, align: 4 },
   });
 });
@@ -49,19 +49,16 @@ describe("pprint", () => {
       `
 T0 = Bool
 T1 = F64
-T2 = (T1, T1)
-x0: T2 -> T1 {
-  x1: T1 = x0.0
-  x2: T1 = x0.1
-  x3: T0 = x1 < x2
-  x4: T1 = x1 * x2
-  x5: T1 = x2 - x1
-  x6: T1 = x4 + x1
-  x7: T1 = x5 * x2
-  x8: T1 = x3 ? x6 : x7
-  x9: T1 = x8 + x1
-  x10: T1 = x2 + x9
-  x10
+(x0: T1, x1: T1) -> T1 {
+  x2: T0 = x0 < x1
+  x3: T1 = x0 * x1
+  x4: T1 = x1 - x0
+  x5: T1 = x3 + x0
+  x6: T1 = x4 * x1
+  x7: T1 = x2 ? x5 : x6
+  x8: T1 = x7 + x0
+  x9: T1 = x1 + x8
+  x9
 }
 `.trimStart(),
     );
@@ -79,17 +76,11 @@ x0: T2 -> T1 {
       `
 T0 = Bool
 T1 = F64
-T2 = (T1)
-f0 = F0<>
-f1 = F1<>
-x0: T2 -> T1 {
-  x1: T1 = x0.0
-  x2: T2 = (x1)
-  x3: T1 = f0(x2)
-  x4: T2 = (x1)
-  x5: T1 = f1(x4)
-  x6: T1 = x3 + x5
-  x6
+(x0: T1) -> T1 {
+  x1: T1 = f0<>(x0)
+  x2: T1 = f1<>(x0)
+  x3: T1 = x1 + x2
+  x3
 }
 `.trimStart(),
     );
@@ -107,15 +98,13 @@ x0: T2 -> T1 {
       `
 T0 = Bool
 T1 = F64
-T2 = (T1)
-x0: T2 -> T1 {
-  x1: T1 = x0.0
-  x2: T0 = true
-  x3: T0 = not x2
-  x4: T1 = -x1
-  x5: T1 = |x4|
-  x6: T1 = sqrt(x1)
-  x6
+(x0: T1) -> T1 {
+  x1: T0 = true
+  x2: T0 = not x1
+  x3: T1 = -x0
+  x4: T1 = |x3|
+  x5: T1 = sqrt(x0)
+  x5
 }
 `.trimStart(),
     );
@@ -142,33 +131,30 @@ x0: T2 -> T1 {
       `
 T0 = Bool
 T1 = F64
-T2 = (T1, T1)
-x0: T2 -> T0 {
-  x1: T1 = x0.0
-  x2: T1 = x0.1
-  x3: T1 = x1 + x2
-  x4: T1 = x1 - x2
-  x5: T1 = x1 * x2
-  x6: T1 = x1 / x2
-  x7: T0 = true
-  x8: T0 = false
-  x9: T0 = x7 and x8
-  x10: T0 = true
-  x11: T0 = false
-  x12: T0 = x10 or x11
-  x13: T0 = true
-  x14: T0 = false
-  x15: T0 = x13 iff x14
-  x16: T0 = true
-  x17: T0 = false
-  x18: T0 = x16 xor x17
-  x19: T0 = x1 != x2
-  x20: T0 = x1 < x2
-  x21: T0 = x1 <= x2
-  x22: T0 = x1 == x2
-  x23: T0 = x1 > x2
-  x24: T0 = x5 >= x6
-  x24
+(x0: T1, x1: T1) -> T0 {
+  x2: T1 = x0 + x1
+  x3: T1 = x0 - x1
+  x4: T1 = x0 * x1
+  x5: T1 = x0 / x1
+  x6: T0 = true
+  x7: T0 = false
+  x8: T0 = x6 and x7
+  x9: T0 = true
+  x10: T0 = false
+  x11: T0 = x9 or x10
+  x12: T0 = true
+  x13: T0 = false
+  x14: T0 = x12 iff x13
+  x15: T0 = true
+  x16: T0 = false
+  x17: T0 = x15 xor x16
+  x18: T0 = x0 != x1
+  x19: T0 = x0 < x1
+  x20: T0 = x0 <= x1
+  x21: T0 = x0 == x1
+  x22: T0 = x0 > x1
+  x23: T0 = x4 >= x5
+  x23
 }
 `.trimStart(),
     );

--- a/packages/core/src/ffi.ts
+++ b/packages/core/src/ffi.ts
@@ -24,8 +24,8 @@ export interface Fn {
   f: wasm.Func;
 }
 
-export const bake = (ctx: wasm.Context, main: number): Fn => {
-  const f = wasm.bake(ctx, main);
+export const bake = (ctx: wasm.Context, ret: number, main: wasm.Block): Fn => {
+  const f = wasm.bake(ctx, ret, main);
   const fn: Fn = { f };
   registry.register(fn, () => f.free());
   return fn;
@@ -39,24 +39,16 @@ export interface Body {
    */
   ctx: wasm.Context;
   main: wasm.Block;
-  arg: number;
-  args: number[];
 }
 
 export const make = (
   generics: number,
   types: Ty[],
   params: Uint32Array,
-  ret: number,
 ): Body => {
-  const x = wasm.make(generics, types, params, ret);
+  const x = wasm.make(generics, types, params);
   try {
-    return {
-      ctx: x.ctx(),
-      main: x.main(),
-      arg: x.arg,
-      args: Array.from(x.args()),
-    };
+    return { ctx: x.ctx(), main: x.main() };
   } finally {
     x.free();
   }
@@ -66,8 +58,8 @@ export const interp = (
   f: Fn,
   types: Ty[],
   generics: Uint32Array,
-  arg: Val,
-): Val => wasm.interp(f.f, types, generics, arg);
+  args: Val[],
+): Val => wasm.interp(f.f, types, generics, args);
 
 export { Block, Context } from "@rose-lang/wasm";
 export type { Ty, Val };

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -3,12 +3,12 @@ import {
   Bool,
   Real,
   add,
-  cond,
   div,
   fn,
   interp,
   lt,
   mul,
+  select,
   sub,
 } from "./index.js";
 
@@ -25,26 +25,14 @@ test("basic arithmetic", () => {
 });
 
 test("branch", () => {
-  const f = fn([Bool], Real, (x) =>
-    cond(
-      x,
-      () => 1,
-      () => 2,
-    ),
-  );
+  const f = fn([Bool], Real, (x) => select(x, 1, 2));
   const g = interp(f);
   expect(g(false)).toBe(2);
   expect(g(true)).toBe(1);
 });
 
 test("call", () => {
-  const ifCond = fn([Bool, Real, Real], Real, (p, x, y) =>
-    cond(
-      p,
-      () => x,
-      () => y,
-    ),
-  );
+  const ifCond = fn([Bool, Real, Real], Real, (p, x, y) => select(p, x, y));
   const f = fn([Real], Real, (x) => ifCond(lt(x, 0), 0, x));
   const relu = interp(f);
   expect(relu(-1)).toBe(0);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,7 +8,7 @@ export const Bool: Bools = { tag: "Bool" };
 export type Real = real.Real;
 export const Real: Reals = { tag: "Real" };
 
-export { and, cond, iff, not, or, xor } from "./bool.js";
+export { and, iff, not, or, select, xor } from "./bool.js";
 export { fn } from "./fn.js";
 export { interp } from "./interp.js";
 export {

--- a/packages/core/src/interp.ts
+++ b/packages/core/src/interp.ts
@@ -34,6 +34,6 @@ export const interp =
   // just return a closure that calls the interpreter
   (...args: Args<A>) => {
     // TODO: support generics
-    const x = ffi.interp(f.f, [], new Uint32Array(), { Tuple: args.map(pack) });
+    const x = ffi.interp(f.f, [], new Uint32Array(), args.map(pack));
     return unpack(x) as Resolve<R>;
   };


### PR DESCRIPTION
Over the past couple weeks @ravenrothkopf and I worked through automatic differentiation on a bunch of examples, and we realized a couple things:

- As [the Dex paper](https://dl.acm.org/doi/pdf/10.1145/3473593) notes, we need a `Read` kind of `Ref` to serve as the transpose for `Accum`.
- In contrast to Dex, we actually don't need a constraint stating that a type is a `Vector` space; instead, when we accumulate, we can just take an existing value of any type to choose the topology, and then work inside the dynamically-defined topology of that value. This will become more important when we #65 but for now it just means that `Bool`/`Fin`/etc stay as-is instead of being transformed into `Unit`.
- We can't handle branching until we #65, so instead for now we're just replacing `If` with a `Select` expression just like [Wasm's](https://developer.mozilla.org/en-US/docs/WebAssembly/Reference/Control_flow/Select).
- Dex doesn't handle nested `Ref`s, and we can't either; to deal with this, we need to allow functions to take multiple parameters.

This PR makes the necessary changes to our codebase to accommodate those IR changes, and also simplifes the IR in a couple other ways:

- Every instance of `Vec<T>` is replaced with `Box<[T]>` to save space, because the former stores three pointers while the latter only uses two; the exception is `Ty` which we're leaving as `Vec<T>` for now because [ts-rs](https://github.com/Aleph-Alpha/ts-rs) does not support `Box<[T]>` or `Rc<[T]>`.
- No more `Func` and `Block`. Each `Call` now directly encodes the generic types at that callsite, and each `For`, `Read`, and `Accum` now directly owns its body.
- The `Scope` type now explicitly says what `Constraint` it satisfies, because otherwise typechecking the IR would be more annoying.