### PR TITLE
Remove redundant `index` type from `Expr::For`

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -155,9 +155,7 @@ pub enum Expr {
         args: Box<[id::Var]>,
     },
     For {
-        /// Must satisfy `Constraint::Index`.
-        index: id::Ty,
-        /// has type `index`.
+        /// Type must satisfy `Constraint::Index`.
         arg: id::Var,
         body: Box<[Instr]>,
         /// Variable from `body` holding an array element.

--- a/crates/frontend/src/translate.rs
+++ b/crates/frontend/src/translate.rs
@@ -341,7 +341,6 @@ impl<'input, 'a> BlockCtx<'input, 'a> {
                 Ok(self.instr(
                     v,
                     ir::Expr::For {
-                        index: i,
                         arg,
                         body,
                         ret: elem,

--- a/crates/interp/src/lib.rs
+++ b/crates/interp/src/lib.rs
@@ -231,13 +231,8 @@ impl<'a, F: FuncNode> Interpreter<'a, F> {
                 let vals = args.iter().map(|id| self.vars[id.var()].clone().unwrap());
                 call(self.f.get(*id).unwrap(), self.typemap, &resolved, vals)
             }
-            Expr::For {
-                index,
-                arg,
-                body,
-                ret,
-            } => {
-                let n = match self.typemap[self.types[index.ty()].ty()] {
+            Expr::For { arg, body, ret } => {
+                let n = match self.typemap[self.types[self.f.def().vars[arg.var()].ty()].ty()] {
                     Ty::Fin { size } => size,
                     _ => unreachable!(),
                 };

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -134,13 +134,13 @@ pub fn pprint(f: &Func) -> Result<String, JsError> {
                 print_elems(s, 'x', args.iter().map(|arg| arg.var()))?;
                 writeln!(&mut s, ")")?;
             }
-            rose::Expr::For {
-                index,
-                arg,
-                body,
-                ret,
-            } => {
-                writeln!(&mut s, "for x{}: T{} {{", arg.var(), index.ty())?;
+            rose::Expr::For { arg, body, ret } => {
+                writeln!(
+                    &mut s,
+                    "for x{}: T{} {{",
+                    arg.var(),
+                    def.vars[arg.var()].ty()
+                )?;
                 print_block(s, def, spaces + 2, body, *ret)?;
                 for _ in 0..spaces {
                     write!(&mut s, " ")?;
@@ -768,14 +768,7 @@ impl Context {
 
     // `rose::Expr::For`
     #[wasm_bindgen]
-    pub fn arr(
-        &mut self,
-        b: &mut Block,
-        index: usize,
-        arg: usize,
-        body: Block,
-        out: usize,
-    ) -> usize {
+    pub fn arr(&mut self, b: &mut Block, arg: usize, body: Block, out: usize) -> usize {
         let arg = id::var(arg);
         let ret = id::var(out);
         let ty = self.ty(rose::Ty::Array {
@@ -783,7 +776,6 @@ impl Context {
             elem: self.get(ret),
         });
         let expr = rose::Expr::For {
-            index: id::ty(index),
             arg,
             body: body.code.into(),
             ret,


### PR DESCRIPTION
While simplifying the compound instructions in #64, I didn't realize that the `index` field of `Expr::For` is redundant, because it's always going to be the same as the type of `arg`. This PR removes that redundant `index` field.

All the resulting changes here are uninteresting, with the possible exception of `rose-interp`: we add a new call to the `.def()` method on the `FuncNode`. This should be fine because conventionally this method is very cheap, but perhaps later we might want to modify the interpreter to keep a direct reference to the function instead of just the `FuncNode`; this is the strategy used in #53, for instance.