### PR TITLE
Support structs

### DIFF
--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -40,22 +40,44 @@ pub fn layouts() -> Result<JsValue, serde_wasm_bindgen::Error> {
     ])
 }
 
+mod str_id {
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    pub struct StrId(usize);
+
+    pub fn str_id(id: usize) -> StrId {
+        StrId(id)
+    }
+
+    impl StrId {
+        pub fn str(self) -> usize {
+            self.0
+        }
+    }
+}
+
+use str_id::{str_id, StrId};
+
+#[derive(Debug)]
+struct Inner {
+    deps: Box<[Func]>,
+    def: rose::Function,
+    structs: Box<[Option<Box<[StrId]>>]>,
+}
+
 /// A node in a reference-counted acyclic digraph of functions.
 #[wasm_bindgen]
 #[derive(Clone, Debug)]
 pub struct Func {
-    rc: Rc<(Box<[Func]>, rose::Function)>,
+    rc: Rc<Inner>,
 }
 
 impl<'a> rose::FuncNode for &'a Func {
     fn def(&self) -> &rose::Function {
-        let (_, def) = self.rc.as_ref();
-        def
+        &self.rc.as_ref().def
     }
 
     fn get(&self, id: id::Function) -> Option<Self> {
-        let (funcs, _) = self.rc.as_ref();
-        funcs.get(id.function())
+        self.rc.as_ref().deps.get(id.function())
     }
 }
 
@@ -226,7 +248,7 @@ pub fn pprint(f: &Func) -> Result<String, JsError> {
     }
 
     let mut s = String::new();
-    let (_, def) = f.rc.as_ref();
+    let def = &f.rc.as_ref().def;
 
     for (i, constraints) in def.generics.iter().enumerate() {
         write!(&mut s, "G{i} = ")?;
@@ -281,6 +303,40 @@ pub fn pprint(f: &Func) -> Result<String, JsError> {
     Ok(s)
 }
 
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+enum Ty {
+    Unit,
+    Bool,
+    F64,
+    Fin { size: usize },
+    Ref { scope: id::Ty, inner: id::Ty },
+    Array { index: id::Ty, elem: id::Ty },
+    Struct { members: Box<[(StrId, id::Ty)]> },
+}
+
+impl Ty {
+    fn ty(&self) -> rose::Ty {
+        match self {
+            Ty::Unit => rose::Ty::Unit,
+            Ty::Bool => rose::Ty::Bool,
+            Ty::F64 => rose::Ty::F64,
+            &Ty::Fin { size } => rose::Ty::Fin { size },
+            &Ty::Ref { scope, inner } => rose::Ty::Ref { scope, inner },
+            &Ty::Array { index, elem } => rose::Ty::Array { index, elem },
+            Ty::Struct { members } => rose::Ty::Tuple {
+                members: members.iter().map(|&(_, t)| t).collect(),
+            },
+        }
+    }
+
+    fn keys(&self) -> Option<Box<[StrId]>> {
+        match self {
+            Ty::Struct { members } => Some(members.iter().map(|&(k, _)| k).collect()),
+            _ => None,
+        }
+    }
+}
+
 /// Metadata about a variable while its containing function is still under construction.
 enum Extra {
     /// Does not depend on any of the function's parameters.
@@ -311,7 +367,7 @@ pub struct FuncBuilder {
     generics: Box<[EnumSet<rose::Constraint>]>,
 
     /// Index of types, with constraints tracked for validation (e.g. array index must be `Index`).
-    types: IndexMap<rose::Ty, EnumSet<rose::Constraint>>,
+    types: IndexMap<Ty, EnumSet<rose::Constraint>>,
 
     /// Variable types, scopes (expired or not?), and dependent definitions.
     vars: Vec<Var>,
@@ -350,17 +406,18 @@ impl FuncBuilder {
         }
         body.finish(&mut self, &mut code);
         Func {
-            rc: Rc::new((
-                self.functions.into(),
-                rose::Function {
+            rc: Rc::new(Inner {
+                deps: self.functions.into(),
+                def: rose::Function {
                     generics: self.generics,
-                    types: self.types.into_keys().collect(),
+                    types: self.types.keys().map(|t| t.ty()).collect(),
                     vars: self.vars.into_iter().map(|x| x.t).collect(),
                     params,
                     ret: id::var(out),
                     body: code.into(),
                 },
-            )),
+                structs: self.types.keys().map(|t| t.keys()).collect(),
+            }),
         }
     }
 
@@ -386,19 +443,19 @@ impl FuncBuilder {
     #[wasm_bindgen(js_name = "isSymbol")]
     pub fn is_symbol(&self, t: usize) -> bool {
         let (ty, _) = self.types.get_index(t).unwrap();
-        // Because the JS API only allows constructing generics that are index types, we don't need
-        // to check for `rose::Constraint::Index` here. If that changes, this code must change too.
-        matches!(ty, rose::Ty::Fin { .. } | rose::Ty::Generic { .. })
+        matches!(ty, Ty::Fin { .. })
     }
 
-    /// Should the type with ID `t` be represented as a JavaScript `Proxy`?
-    ///
-    /// Values of array types must be proxies so that we can use the standard JavaScript indexing
-    /// notation (along with `Symbol`, see above) to generate array accessing code.
-    #[wasm_bindgen(js_name = "isProxy")]
-    pub fn is_proxy(&self, t: usize) -> bool {
+    #[wasm_bindgen(js_name = "isArray")]
+    pub fn is_array(&self, t: usize) -> bool {
         let (ty, _) = self.types.get_index(t).unwrap();
-        matches!(ty, rose::Ty::Array { .. }) // should check for `Tuple` too once we allow structs
+        matches!(ty, Ty::Array { .. })
+    }
+
+    #[wasm_bindgen(js_name = "isStruct")]
+    pub fn is_struct(&self, t: usize) -> bool {
+        let (ty, _) = self.types.get_index(t).unwrap();
+        matches!(ty, Ty::Struct { .. })
     }
 
     /// Return a reference to the type with ID `t` if it exists, `Err` otherwise.
@@ -406,7 +463,7 @@ impl FuncBuilder {
     /// This returns a `Result` with `JsError` because it is a helper method meant to be used by
     /// `pub` methods exposed to JavaScript; don't prefer it for more Rusty stuff, because `JsError`
     /// doesn't implement `Debug` so you can't easily call `Result::unwrap` here.
-    fn ty(&self, t: usize) -> Result<&rose::Ty, JsError> {
+    fn ty(&self, t: usize) -> Result<&Ty, JsError> {
         match self.types.get_index(t) {
             None => Err(JsError::new("type does not exist")),
             Some((ty, _)) => Ok(ty),
@@ -418,7 +475,7 @@ impl FuncBuilder {
     /// `Err` if `t` is out of range or does not represent an array type.
     pub fn index(&self, t: usize) -> Result<usize, JsError> {
         match self.ty(t)? {
-            &rose::Ty::Array { index, elem: _ } => Ok(index.ty()),
+            &Ty::Array { index, elem: _ } => Ok(index.ty()),
             _ => Err(JsError::new("type is not an array")),
         }
     }
@@ -429,10 +486,10 @@ impl FuncBuilder {
     /// not a fixed size (e.g. if it is a generic type parameter of the function).
     pub fn size(&self, t: usize) -> Result<usize, JsError> {
         match self.ty(t)? {
-            &rose::Ty::Array { index, elem: _ } => {
+            &Ty::Array { index, elem: _ } => {
                 let (i, _) = self.types.get_index(index.ty()).unwrap();
                 match i {
-                    &rose::Ty::Fin { size } => Ok(size),
+                    &Ty::Fin { size } => Ok(size),
                     _ => Err(JsError::new("index type is not a fixed size")),
                 }
             }
@@ -445,8 +502,22 @@ impl FuncBuilder {
     /// `Err` if `t` is out of range or does not represent an array type.
     pub fn elem(&self, t: usize) -> Result<usize, JsError> {
         match self.ty(t)? {
-            &rose::Ty::Array { index: _, elem } => Ok(elem.ty()),
+            &Ty::Array { index: _, elem } => Ok(elem.ty()),
             _ => Err(JsError::new("type is not an array")),
+        }
+    }
+
+    pub fn keys(&self, t: usize) -> Result<Vec<usize>, JsError> {
+        match self.ty(t)? {
+            Ty::Struct { members } => Ok(members.iter().map(|&(id, _)| id.str()).collect()),
+            _ => Err(JsError::new("type is not a struct")),
+        }
+    }
+
+    pub fn members(&self, t: usize) -> Result<Vec<usize>, JsError> {
+        match self.ty(t)? {
+            Ty::Struct { members } => Ok(members.iter().map(|&(_, id)| id.ty()).collect()),
+            _ => Err(JsError::new("type is not a struct")),
         }
     }
 
@@ -468,7 +539,7 @@ impl FuncBuilder {
     }
 
     /// Return the type ID for `ty`, creating if needed, and marking its constraints as `constrs`.
-    fn newtype(&mut self, ty: rose::Ty, constrs: EnumSet<rose::Constraint>) -> usize {
+    fn newtype(&mut self, ty: Ty, constrs: EnumSet<rose::Constraint>) -> usize {
         let (i, _) = self.types.insert_full(ty, constrs);
         i
     }
@@ -489,26 +560,26 @@ impl FuncBuilder {
     /// Return the ID for the unit type, creating if needed.
     #[wasm_bindgen(js_name = "tyUnit")]
     pub fn ty_unit(&mut self) -> usize {
-        self.newtype(rose::Ty::Unit, EnumSet::only(rose::Constraint::Value))
+        self.newtype(Ty::Unit, EnumSet::only(rose::Constraint::Value))
     }
 
     /// Return the ID for the boolean type, creating if needed.
     #[wasm_bindgen(js_name = "tyBool")]
     pub fn ty_bool(&mut self) -> usize {
-        self.newtype(rose::Ty::Bool, EnumSet::only(rose::Constraint::Value))
+        self.newtype(Ty::Bool, EnumSet::only(rose::Constraint::Value))
     }
 
     /// Return the ID for the 64-bit floating-point type, creating if needed.
     #[wasm_bindgen(js_name = "tyF64")]
     pub fn ty_f64(&mut self) -> usize {
-        self.newtype(rose::Ty::F64, EnumSet::only(rose::Constraint::Value))
+        self.newtype(Ty::F64, EnumSet::only(rose::Constraint::Value))
     }
 
     /// Return the ID for the type of nonnegative integers less than `size`, creating if needed.
     #[wasm_bindgen(js_name = "tyFin")]
     pub fn ty_fin(&mut self, size: usize) -> usize {
         self.newtype(
-            rose::Ty::Fin { size },
+            Ty::Fin { size },
             rose::Constraint::Value | rose::Constraint::Index,
         )
     }
@@ -522,7 +593,7 @@ impl FuncBuilder {
         // If we support non-`Value` types then we should also check that `elem` satisfies `Value`.
         if constrs.contains(rose::Constraint::Index) {
             Ok(self.newtype(
-                rose::Ty::Array {
+                Ty::Array {
                     index: id::ty(index),
                     elem: id::ty(elem),
                 },
@@ -531,6 +602,20 @@ impl FuncBuilder {
         } else {
             Err(JsError::new("index type cannot be used as an index"))
         }
+    }
+
+    #[wasm_bindgen(js_name = "tyStruct")]
+    pub fn ty_struct(&mut self, keys: &[usize], mems: &[usize]) -> usize {
+        self.newtype(
+            Ty::Struct {
+                members: keys
+                    .iter()
+                    .zip(mems.iter())
+                    .map(|(&s, &t)| (str_id(s), id::ty(t)))
+                    .collect(),
+            },
+            EnumSet::only(rose::Constraint::Value),
+        )
     }
 
     /// Return the ID of a new variable with type ID `t`.
@@ -587,8 +672,8 @@ impl FuncBuilder {
     /// integer type; or if `t` is an integer type which cannot represent the given value of `x`.
     pub fn num(&mut self, t: usize, x: f64) -> Result<usize, JsError> {
         match self.ty(t)? {
-            rose::Ty::F64 => Ok(self.constant(t, rose::Expr::F64 { val: x })),
-            &rose::Ty::Fin { size } => {
+            Ty::F64 => Ok(self.constant(t, rose::Expr::F64 { val: x })),
+            &Ty::Fin { size } => {
                 let y = x as usize;
                 if y as f64 != x {
                     Err(JsError::new("can't be represented by an unsigned integer"))
@@ -602,14 +687,7 @@ impl FuncBuilder {
         }
     }
 
-    /// Return the ID of a new array variable with type ID `t` and elements `xs`.
-    ///
-    /// Assumes that `t` is a valid type ID and `xs` are all valid variable IDs. If there are no
-    /// dependencies on parameters then the new array variable is a constant; otherwise, it is
-    /// attached to whichever parent variable reachable from `xs` has the highest ID.
-    pub fn array(&mut self, t: usize, xs: &[usize]) -> usize {
-        let elems = xs.iter().map(|&x| id::var(x)).collect();
-        let expr = rose::Expr::Array { elems };
+    fn attach(&mut self, t: usize, xs: &[usize], expr: rose::Expr) -> usize {
         match xs
             .iter()
             .filter_map(|&x| match self.vars[x].extra {
@@ -639,6 +717,23 @@ impl FuncBuilder {
         }
     }
 
+    /// Return the ID of a new array variable with type ID `t` and elements `xs`.
+    ///
+    /// Assumes that `t` is a valid type ID and `xs` are all valid variable IDs. If there are no
+    /// dependencies on parameters then the new array variable is a constant; otherwise, it is
+    /// attached to whichever parent variable reachable from `xs` has the highest ID.
+    pub fn array(&mut self, t: usize, xs: &[usize]) -> usize {
+        let elems = xs.iter().map(|&x| id::var(x)).collect();
+        let expr = rose::Expr::Array { elems };
+        self.attach(t, xs, expr)
+    }
+
+    pub fn obj(&mut self, t: usize, xs: &[usize]) -> usize {
+        let members = xs.iter().map(|&x| id::var(x)).collect();
+        let expr = rose::Expr::Tuple { members };
+        self.attach(t, xs, expr)
+    }
+
     /// Resolve `ty` via `generics` and `types`, then return its ID in `typemap`, inserting if need
     /// be.
     ///
@@ -654,7 +749,10 @@ impl FuncBuilder {
     fn resolve(
         &mut self,
         generics: &[usize],
+        strings: &[usize],
+        structs: &[Option<Box<[StrId]>>],
         types: &[Option<id::Ty>],
+        t: usize,
         ty: &rose::Ty,
     ) -> Option<id::Ty> {
         let (deduped, constrs) = match ty {
@@ -662,33 +760,34 @@ impl FuncBuilder {
             rose::Ty::Scope { kind: _, id: _ } => return None,
             rose::Ty::Generic { id } => return Some(id::ty(generics[id.generic()])),
 
-            rose::Ty::Unit => (rose::Ty::Unit, EnumSet::only(rose::Constraint::Value)),
-            rose::Ty::Bool => (rose::Ty::Bool, EnumSet::only(rose::Constraint::Value)),
-            rose::Ty::F64 => (rose::Ty::F64, EnumSet::only(rose::Constraint::Value)),
+            rose::Ty::Unit => (Ty::Unit, EnumSet::only(rose::Constraint::Value)),
+            rose::Ty::Bool => (Ty::Bool, EnumSet::only(rose::Constraint::Value)),
+            rose::Ty::F64 => (Ty::F64, EnumSet::only(rose::Constraint::Value)),
             &rose::Ty::Fin { size } => (
-                rose::Ty::Fin { size },
+                Ty::Fin { size },
                 rose::Constraint::Value | rose::Constraint::Index,
             ),
 
             rose::Ty::Ref { scope, inner } => (
-                rose::Ty::Ref {
+                Ty::Ref {
                     scope: types[scope.ty()]?,
                     inner: types[inner.ty()]?,
                 },
                 EnumSet::empty(),
             ),
             rose::Ty::Array { index, elem } => (
-                rose::Ty::Array {
+                Ty::Array {
                     index: types[index.ty()]?,
                     elem: types[elem.ty()]?,
                 },
                 EnumSet::only(rose::Constraint::Value),
             ),
             rose::Ty::Tuple { members } => (
-                rose::Ty::Tuple {
+                Ty::Struct {
                     members: members
                         .iter()
-                        .map(|&x| types[x.ty()])
+                        .zip(structs[t].as_ref().unwrap().iter())
+                        .map(|(x, s)| Some((str_id(strings[s.str()]), types[x.ty()]?)))
                         .collect::<Option<_>>()?,
                 },
                 EnumSet::only(rose::Constraint::Value),
@@ -704,12 +803,13 @@ impl FuncBuilder {
     ///
     /// The returned `Vec` is always nonempty, since its last element is the return type; all the
     /// other elements are the parameter types.
-    pub fn ingest(&mut self, f: &Func, generics: &[usize]) -> Vec<usize> {
+    pub fn ingest(&mut self, f: &Func, strings: &[usize], generics: &[usize]) -> Vec<usize> {
         let mut types = vec![];
-        let (_, def) = f.rc.as_ref();
+        let inner = f.rc.as_ref();
+        let def = &inner.def;
         // push a corresponding type onto our own `types` for each type in the callee
-        for ty in def.types.iter() {
-            types.push(self.resolve(generics, &types, ty));
+        for (t, ty) in def.types.iter().enumerate() {
+            types.push(self.resolve(generics, strings, &inner.structs, &types, t, ty));
         }
 
         let mut sig: Vec<_> = def
@@ -719,17 +819,6 @@ impl FuncBuilder {
             .collect();
         sig.push(types[def.vars[def.ret.var()].ty()].unwrap().ty());
         sig
-    }
-
-    /// Return the type ID for the existing variable ID `x`.
-    fn var_ty_id(&self, x: id::Var) -> id::Ty {
-        self.vars[x.var()].t
-    }
-
-    /// Return the type for the existing variable ID `x`.
-    fn var_ty(&self, x: id::Var) -> &rose::Ty {
-        let (ty, _) = self.types.get_index(self.var_ty_id(x).ty()).unwrap();
-        ty
     }
 }
 
@@ -756,7 +845,7 @@ impl Block {
 
     /// Pour the contents of this block (including dependent variables) into `code`.
     ///
-    /// Must not use `self.params` or `f.constants`. Marks all variables defined in this block as
+    /// Must not use `f.params` or `f.constants`. Marks all variables defined in this block as
     /// expired.
     fn finish(self, f: &mut FuncBuilder, code: &mut Vec<rose::Instr>) {
         for instr in self.code.into_iter() {
@@ -779,18 +868,16 @@ impl Block {
         x.var()
     }
 
-    /// Add an instruction getting the element of `arr` at index `idx`, and return its variable ID.
-    ///
-    /// Assumes `arr` and `idx` are valid variable IDs, and that `idx` matches up with `arr`'s
-    /// `index` type. `Err` if `arr` is not an array type.
-    pub fn index(&mut self, f: &mut FuncBuilder, arr: usize, idx: usize) -> Result<usize, JsError> {
+    pub fn index(&mut self, f: &mut FuncBuilder, t: usize, arr: usize, idx: usize) -> usize {
         let array = id::var(arr);
         let index = id::var(idx);
-        let t = match f.var_ty(array) {
-            &rose::Ty::Array { index: _, elem } => elem,
-            _ => return Err(JsError::new("not an array")),
-        };
-        Ok(self.instr(f, t, rose::Expr::Index { array, index }))
+        self.instr(f, id::ty(t), rose::Expr::Index { array, index })
+    }
+
+    pub fn member(&mut self, f: &mut FuncBuilder, t: usize, x: usize, mem: usize) -> usize {
+        let tuple = id::var(x);
+        let member = id::member(mem);
+        self.instr(f, id::ty(t), rose::Expr::Member { tuple, member })
     }
 
     // unary

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -40,22 +40,18 @@ pub fn layouts() -> Result<JsValue, serde_wasm_bindgen::Error> {
     ])
 }
 
-mod str_id {
-    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-    pub struct StrId(usize);
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+struct StrId(usize);
 
-    pub fn str_id(id: usize) -> StrId {
-        StrId(id)
-    }
-
-    impl StrId {
-        pub fn str(self) -> usize {
-            self.0
-        }
-    }
+fn str_id(id: usize) -> StrId {
+    StrId(id)
 }
 
-use str_id::{str_id, StrId};
+impl StrId {
+    fn str(self) -> usize {
+        self.0
+    }
+}
 
 #[derive(Debug)]
 struct Inner {

--- a/packages/core/src/impl.ts
+++ b/packages/core/src/impl.ts
@@ -23,10 +23,16 @@ const funcs = new FinalizationRegistry((f: wasm.Func) => f.free());
  */
 export const inner = Symbol("inner");
 
+const strings = Symbol("strings");
+
 /** An abstract function. */
 export interface Fn {
   [inner]: wasm.Func;
+  [strings]: string[];
 }
+
+/** Property key for a variable ID. */
+const variable = Symbol("variable");
 
 /**
  * An abstract variable.
@@ -37,13 +43,11 @@ export interface Fn {
  * instead represented by `Symbol`, and non-primitive types are represented by
  * `Proxy`.
  */
-class Var {
-  id: number;
-
-  constructor(id: number) {
-    this.id = id;
-  }
+interface Var {
+  [variable]: number;
 }
+
+const newVar = (id: number): Var => ({ [variable]: id });
 
 /** An abstract null value. */
 export type Null = null | Var;
@@ -65,12 +69,6 @@ export interface Vec<T> {
 /** A concrete or abstract vector. */
 type ArrayOrVec<T> = T[] | Vec<T>;
 
-/** An abstract value that is not a concrete vector. */
-type Symbolic = Null | Bool | Real | Nat | Vec<Symbolic>;
-
-/** Any abstract value. */
-type Value = Symbolic | Value[];
-
 /** The context for an abstract function under construction. */
 interface Context {
   /** Handle to Rust-side information about the function itself. */
@@ -79,83 +77,77 @@ interface Context {
   /** Handle to Rust-side information about the current block being built. */
   block: wasm.Block;
 
-  /** Variable IDs for symbols, which are used to represent abstract indices. */
-  symbols: Map<symbol, number>;
-
   /**
-   * Variable IDs for literals (primitives/aggregates), indexed by type ID.
+   * Variable IDs for abstract values, indexed by type ID.
    *
    * For instance, the number `42` may represent a floating-point number, or it
    * may represent a natural number that is being used as an index. Similarly,
    * an array of numbers could be a vector of floating-point numbers or a vector
    * of indices. We need to know the type first before we can interpret it.
    */
-  literals: Map<number, Map<Value, number>>;
+  variables: Map<number, Map<unknown, number>>;
+
+  strings: string[];
+
+  stringIds: Map<string, number>;
 }
 
-/**
- * Property key for the variable ID of a `Proxy` vector.
- *
- * Such `Proxy` vectors interpret access through any other property key as a
- * request to emit an indexing instruction into the current block.
- */
-const variable = Symbol("variable");
+const typeMap = (ctx: Context, t: number): Map<unknown, number> => {
+  let map = ctx.variables.get(t);
+  if (map === undefined) {
+    // the map is keyed by type, so we don't always have an entry for every
+    // possible type; if we're missing one, just initialize it as an empty map
+    map = new Map();
+    ctx.variables.set(t, map);
+  }
+  return map;
+};
 
 /**
  * Return the variable ID for the given abstract value with the given type.
  *
  * Throws if the value does not match the type.
  */
-const valId = (ctx: Context, t: number, x: Value): number => {
-  // various possible values that don't actually fall under `Value`; these are
-  // disallowed by TypeScript, but TypeScript can be circumvented e.g. by `any`
-  if (x === undefined) throw Error("undefined value");
-  if (typeof x === "bigint") throw Error("bigint not supported");
-  if (typeof x === "string") throw Error("string not supported");
+const valId = (ctx: Context, t: number, x: unknown): number => {
+  const map = typeMap(ctx, t);
+  let id = map.get(x);
+  if (id !== undefined) return ctx.func.expect(t, id); // check if out of scope
 
-  // a `Var` could be misused or even stray from a different context, so we
-  // check its type via `expect`
-  if (x instanceof Var) return ctx.func.expect(t, x.id);
-
-  if (typeof x === "symbol") {
-    const id = ctx.symbols.get(x);
-    if (id === undefined) throw Error("undefined symbol");
-    return ctx.func.expect(t, id);
-  }
-
-  let id: number | undefined;
-  if (typeof x === "object" && x !== null) {
-    // this means `x` is either an actual `Array` or a `Proxy` vector
-    id = (x as any)[variable];
-    if (id !== undefined) return ctx.func.expect(t, id); // `Proxy` vector
-  }
-
-  let map = ctx.literals.get(t);
-  if (map === undefined) {
-    // the map is keyed by type, so we don't always have an entry for every
-    // possible type; if we're missing one, just initialize it as an empty map
-    map = new Map();
-    ctx.literals.set(t, map);
-  }
-  id = map.get(x);
-  // see if we already have an entry for this type and value; if so then we're
-  // done! no need to call `expect` because we checked it when inserting before
-  if (id !== undefined) return id;
-
-  if (x === null) id = ctx.func.unit(t);
-  else if (typeof x === "boolean") id = ctx.func.bool(t, x);
+  if (typeof x === "boolean") id = ctx.func.bool(t, x);
   else if (typeof x === "number") id = ctx.func.num(t, x);
-  else if (Array.isArray(x)) {
-    const size = ctx.func.size(t);
-    const elem = ctx.func.elem(t);
-    if (x.length !== size) throw Error("wrong array size");
-    const xs = new Uint32Array(size);
-    // this is an example of why it's good to check for `undefined` above; an
-    // array can still have holes even if its length is correct, and that's
-    // something TypeScript doesn't check regardless
-    for (let i = 0; i < size; ++i) xs[i] = valId(ctx, elem, x[i]);
-    id = ctx.func.array(t, xs);
-  } else throw Error("unknown kind of value");
+  else if (typeof x === "object") {
+    if (x === null) id = ctx.func.unit(t);
+    else {
+      id = (x as any)[variable];
+      if (typeof id === "number") id = ctx.func.expect(t, id);
+      else {
+        if (Array.isArray(x)) {
+          const size = ctx.func.size(t);
+          const elem = ctx.func.elem(t);
+          if (x.length !== size) throw Error("wrong array size");
+          const xs = new Uint32Array(size);
+          for (let i = 0; i < size; ++i) xs[i] = valId(ctx, elem, x[i]);
+          id = ctx.func.array(t, xs);
+        } else {
+          const keys = ctx.func.keys(t);
+          const mems = ctx.func.members(t);
+          const entries = Object.entries(x).sort(([a], [b]) => compare(a, b));
+          if (
+            !(
+              entries.length === keys.length &&
+              // they're sorted
+              entries.every(([k], i) => k === ctx.strings[keys[i]])
+            )
+          )
+            throw Error("wrong struct keys");
+          const ys = new Uint32Array(
+            entries.map(([, y], i) => valId(ctx, mems[i], y)),
+          );
+          id = ctx.func.obj(t, ys);
+        }
+      }
+    }
+  } else throw Error("invalid value");
 
   map.set(x, id);
   return id;
@@ -191,32 +183,57 @@ type Reals = typeof Real;
 /** Representation of a bounded index type (it's just the upper bound). */
 type Nats = number;
 
-/** Representation of a vector type. */
-class Vecs<K, V> {
-  index: K;
-  elem: V;
+const foo = Symbol("index");
 
-  constructor(index: K, elem: V) {
-    this.index = index;
-    this.elem = elem;
-  }
+const bar = Symbol("elem");
+
+/** Representation of a vector type. */
+interface Vecs<K, V> {
+  [foo]: K;
+  [bar]: V;
 }
 
-/** JavaScript-side representation of a type. */
-type Type = Nulls | Bools | Reals | Nats | Vecs<Type, Type>;
-
-/** Return the type ID for `ty` in `ctx`, creating the type if needed. */
-const tyId = (ctx: Context, ty: Type): number => {
-  if (ty === Null) return ctx.func.tyUnit();
-  if (ty === Bool) return ctx.func.tyBool();
-  if (ty === Real) return ctx.func.tyF64();
-  if (typeof ty === "number") return ctx.func.tyFin(ty);
-  return ctx.func.tyArray(tyId(ctx, ty.index), tyId(ctx, ty.elem));
+/** The type of vectors from the index type `K` to the element type `V`. */
+export const Vec = <K, V>(index: K, elem: V): Vecs<K, V> => {
+  return { [foo]: index, [bar]: elem };
 };
 
-/** The type of vectors from the index type `K` to the element type `V`. */
-export const Vec = <K, V>(index: K, elem: V): Vecs<K, V> =>
-  new Vecs(index, elem);
+// TODO: make this locale-independent
+const compare = (a: string, b: string): number => a.localeCompare(b);
+
+const intern = (ctx: Context, strs: string[]): Uint32Array =>
+  new Uint32Array(
+    strs.map((s) => {
+      let i = ctx.stringIds.get(s);
+      if (i === undefined) {
+        i = ctx.strings.length;
+        ctx.strings.push(s);
+        ctx.stringIds.set(s, i);
+      }
+      return i;
+    }),
+  );
+
+/** Return the type ID for `ty` in `ctx`, creating the type if needed. */
+const tyId = (ctx: Context, ty: unknown): number => {
+  if (ty === Null) return ctx.func.tyUnit();
+  else if (ty === Bool) return ctx.func.tyBool();
+  else if (ty === Real) return ctx.func.tyF64();
+  else if (typeof ty === "number") return ctx.func.tyFin(ty);
+  else if (typeof ty === "object" && ty !== null) {
+    if (foo in ty && bar in ty)
+      return ctx.func.tyArray(tyId(ctx, ty[foo]), tyId(ctx, ty[bar]));
+    else {
+      const entries = Object.entries(ty).sort(([a], [b]) => compare(a, b));
+      const strs = intern(
+        ctx,
+        entries.map(([s]) => s),
+      );
+      const tys = new Uint32Array(entries.map(([, t]) => tyId(ctx, t)));
+      return ctx.func.tyStruct(strs, tys);
+    }
+  } else throw Error("invalid type");
+};
 
 /**
  * Return a symbolic JS representation of the variable with the given `id`.
@@ -225,13 +242,14 @@ export const Vec = <K, V>(index: K, elem: V): Vecs<K, V> =>
  * it must be represented by a `Symbol`, and if it is of a vector type then it
  * must be represented by a `Proxy`.
  */
-const idVal = (ctx: Context, t: number, id: number): Symbolic => {
+const idVal = (ctx: Context, t: number, id: number): unknown => {
   if (ctx.func.isSymbol(t)) {
     const sym = Symbol();
-    ctx.symbols.set(sym, id);
+    typeMap(ctx, t).set(sym, id);
     return sym;
-  } else if (ctx.func.isProxy(t)) return arrayProxy(t, id);
-  else return new Var(id);
+  } else if (ctx.func.isArray(t)) return arrayProxy(ctx, t, id);
+  else if (ctx.func.isStruct(t)) return structProxy(ctx, t, id);
+  else return newVar(id);
 };
 
 /**
@@ -241,29 +259,56 @@ const idVal = (ctx: Context, t: number, id: number): Symbolic => {
  * property key. Any string access will be parsed as a literal integer index.
  * Any other symbol access will use the `Context`'s `symbols` map.
  */
-const arrayProxy = (t: number, v: number): Vec<Symbolic> => {
+const arrayProxy = (ctx: Context, t: number, v: number): Vec<unknown> => {
+  const index = ctx.func.index(t);
+  const elem = ctx.func.elem(t);
   return new Proxy(
     {},
     {
-      get: (target, prop): Symbolic => {
+      get: (target, prop) => {
+        if (getCtx() !== ctx) throw Error("array escaped its context");
         if (prop === variable) return v;
-        const ctx = getCtx();
-        const index = ctx.func.index(t);
-        const elem = ctx.func.elem(t);
         const i = typeof prop === "string" ? parseInt(prop, 10) : prop;
-        const x = ctx.block.index(ctx.func, v, valId(ctx, index, i));
+        const x = ctx.block.index(ctx.func, elem, v, valId(ctx, index, i));
         return idVal(ctx, elem, x);
       },
     },
   );
 };
 
+const structProxy = (
+  ctx: Context,
+  t: number,
+  x: number,
+): { [K: string]: unknown } => {
+  const keys = ctx.func.keys(t);
+  const mems = ctx.func.members(t);
+  const map = new Map<string, number>();
+  for (let i = 0; i < keys.length; ++i) map.set(ctx.strings[keys[i]], i);
+  return new Proxy(
+    {},
+    {
+      get: (target, prop) => {
+        if (getCtx() !== ctx) throw Error("struct escaped its context");
+        if (prop === variable) return x;
+        if (typeof prop === "symbol") throw Error("unexpected symbol");
+        const i = map.get(prop);
+        if (i === undefined) throw Error("unexpected key");
+        const t = mems[i];
+        const y = ctx.block.member(ctx.func, t, x, i);
+        return idVal(ctx, t, y);
+      },
+    },
+  );
+};
+
 /** Insert a call instruction to `f` in the current context. */
-const call = (f: Fn, generics: Uint32Array, args: Value[]): Symbolic => {
+const call = (f: Fn, generics: Uint32Array, args: unknown[]): unknown => {
   const ctx = getCtx();
+  const strs = intern(ctx, f[strings]);
   // we first need to pull in the signature types from `f` so we know how to
   // interpret the abstract values for its arguments
-  const sig = ctx.func.ingest(f[inner], generics);
+  const sig = ctx.func.ingest(f[inner], strs, generics);
   const ret = sig[sig.length - 1]; // the last type is the return type
   // TODO: we should probably check that `args` is the right length
   const vars = new Uint32Array(args.map((arg, i) => valId(ctx, sig[i], arg)));
@@ -278,7 +323,7 @@ const call = (f: Fn, generics: Uint32Array, args: Value[]): Symbolic => {
  * where the abstract value is being synthesized (e.g. the parameters of the
  * body of `fn` or `vec`, or the returned value from a call or `select`).
  */
-type ToSymbolic<T extends Type> = T extends Nulls
+type ToSymbolic<T> = T extends Nulls
   ? Null
   : T extends Bools
   ? Bool
@@ -286,9 +331,11 @@ type ToSymbolic<T extends Type> = T extends Nulls
   ? Real
   : T extends Nats
   ? Nat
-  : T extends Vecs<any, infer V extends Type>
+  : T extends Vecs<any, infer V>
   ? Vec<ToSymbolic<V>>
-  : unknown; // TODO: is `unknown` the right default here? what about `never`?
+  : {
+      [K in keyof T]: ToSymbolic<T[K]>;
+    };
 
 /**
  * Map from a type of a type to the type of the abstract values it represents.
@@ -297,7 +344,7 @@ type ToSymbolic<T extends Type> = T extends Nulls
  * the abstract value is provided by the user (e.g. the returned value in the
  * body of `fn` or `vec`, or the inputs to a call or `select).
  */
-type ToValue<T extends Type> = T extends Nulls
+type ToValue<T> = T extends Nulls
   ? Null
   : T extends Bools
   ? Bool
@@ -305,22 +352,24 @@ type ToValue<T extends Type> = T extends Nulls
   ? Real
   : T extends Nats
   ? Nat
-  : T extends Vecs<any, infer V extends Type>
+  : T extends Vecs<any, infer V>
   ? Vec<ToValue<V>> | ToValue<V>[]
-  : unknown; // TODO: is `unknown` the right default here? what about `never`?
+  : {
+      [K in keyof T]: ToValue<T[K]>;
+    };
 
 /** Map from a parameter type array to a symbolic parameter value type array. */
-type SymbolicParams<T extends readonly Type[]> = {
+type SymbolicParams<T extends readonly any[]> = {
   [K in keyof T]: ToSymbolic<T[K]>;
 };
 
 /** Map from a parameter type array to an abstract parameter value type array. */
-type ValueParams<T extends readonly Type[]> = {
+type ValueParams<T extends readonly any[]> = {
   [K in keyof T]: ToValue<T[K]>;
 };
 
 /** Constructs an abstract function with the given `types` for parameters. */
-export const fn = <const P extends readonly Type[], R extends Type>(
+export const fn = <const P extends readonly any[], R extends any>(
   params: P,
   ret: R,
   f: (...args: SymbolicParams<P>) => ToValue<R>,
@@ -329,28 +378,27 @@ export const fn = <const P extends readonly Type[], R extends Type>(
   if (context !== undefined)
     throw Error("can't define a function while defining another function");
   let out: number | undefined = undefined; // function return variable ID
+  let strs: string[] = [];
   const builder = new wasm.FuncBuilder(0); // TODO: support generics
   const body = new wasm.Block();
   try {
     const ctx = {
       func: builder,
       block: body,
-      symbols: new Map(),
-      literals: new Map(),
+      variables: new Map(),
+      strings: strs,
+      stringIds: new Map(),
     };
     context = ctx;
-    const x = f(
-      ...(params.map((ty): Symbolic => {
-        const t = tyId(ctx, ty);
-        // it's important that `map` runs eagerly an in order, because the
-        // ordering of these calls to `param` must match the order of `params`
-        return idVal(ctx, t, ctx.func.param(t));
-      }) as SymbolicParams<P>),
-    );
-    // TODO: we have to wait until after running the function body to typecheck
-    // the returned value, but we can check whether the return type itself makes
-    // sense before running the function body; maybe we should do that?
-    out = valId(ctx, tyId(ctx, ret), x as Value);
+    const args = params.map((ty) => {
+      const t = tyId(ctx, ty);
+      // it's important that `map` runs eagerly an in order, because the
+      // ordering of these calls to `param` must match the order of `params`
+      return idVal(ctx, t, ctx.func.param(t));
+    }) as SymbolicParams<P>;
+    const ty = tyId(ctx, ret);
+    const x = f(...args);
+    out = valId(ctx, ty, x);
   } finally {
     context = undefined;
     if (out === undefined) {
@@ -364,14 +412,15 @@ export const fn = <const P extends readonly Type[], R extends Type>(
   const func = builder.finish(out, body);
   const g: any = (...args: SymbolicParams<P>): ToSymbolic<R> =>
     // TODO: support generics
-    call(g, new Uint32Array(), args as Value[]) as ToSymbolic<R>;
+    call(g, new Uint32Array(), args as unknown[]) as ToSymbolic<R>;
   funcs.register(g, func);
   g[inner] = func;
+  g[strings] = strs;
   return g;
 };
 
 /** A concrete value. */
-type Js = null | boolean | number | Js[];
+type Js = null | boolean | number | Js[] | { [K: string]: Js };
 
 /** Translate a concrete value from the raw format given by the interpreter. */
 const translate = (x: RawVal): Js => {
@@ -385,13 +434,13 @@ const translate = (x: RawVal): Js => {
 };
 
 /** Map from an abstract value type to its corresponding concrete value type. */
-type ToJs<T extends Value> = T extends ArrayOrVec<infer V extends Value>
+type ToJs<T> = T extends ArrayOrVec<infer V>
   ? ToJs<V>[]
-  : Exclude<T, Var | symbol>;
+  : Exclude<{ [K in keyof T]: ToJs<T[K]> }, Var | symbol>;
 
 /** Concretize the nullary abstract function `f` using the interpreter. */
 export const interp =
-  <R extends Value>(f: Fn & (() => R)): (() => ToJs<R>) =>
+  <R>(f: Fn & (() => R)): (() => ToJs<R>) =>
   // TODO: support interpreting functions with parameters and generics
   () =>
     translate(wasm.interp(f[inner])) as ToJs<R>;
@@ -403,35 +452,35 @@ const boolId = (ctx: Context, x: Bool): number =>
 /** Return the negation of the abstract boolean `p`. */
 export const not = (p: Bool): Bool => {
   const ctx = getCtx();
-  return new Var(ctx.block.not(ctx.func, boolId(ctx, p)));
+  return newVar(ctx.block.not(ctx.func, boolId(ctx, p)));
 };
 
 /** Return the conjunction of the abstract booleans `p` and `q`. */
 export const and = (p: Bool, q: Bool): Bool => {
   const ctx = getCtx();
-  return new Var(ctx.block.and(ctx.func, boolId(ctx, p), boolId(ctx, q)));
+  return newVar(ctx.block.and(ctx.func, boolId(ctx, p), boolId(ctx, q)));
 };
 
 /** Return the disjunction of the abstract booleans `p` and `q`. */
 export const or = (p: Bool, q: Bool): Bool => {
   const ctx = getCtx();
-  return new Var(ctx.block.or(ctx.func, boolId(ctx, p), boolId(ctx, q)));
+  return newVar(ctx.block.or(ctx.func, boolId(ctx, p), boolId(ctx, q)));
 };
 
 /** Return the biconditional of the abstract booleans `p` and `q`. */
 export const iff = (p: Bool, q: Bool): Bool => {
   const ctx = getCtx();
-  return new Var(ctx.block.iff(ctx.func, boolId(ctx, p), boolId(ctx, q)));
+  return newVar(ctx.block.iff(ctx.func, boolId(ctx, p), boolId(ctx, q)));
 };
 
 /** Return the exclusive disjunction of the abstract booleans `p` and `q`. */
 export const xor = (p: Bool, q: Bool): Bool => {
   const ctx = getCtx();
-  return new Var(ctx.block.xor(ctx.func, boolId(ctx, p), boolId(ctx, q)));
+  return newVar(ctx.block.xor(ctx.func, boolId(ctx, p), boolId(ctx, q)));
 };
 
 /** Return an abstract value selecting between `then` and `els` via `cond`. */
-export const select = <T extends Type>(
+export const select = <T>(
   cond: Bool,
   ty: T,
   then: ToValue<T>,
@@ -440,8 +489,8 @@ export const select = <T extends Type>(
   const ctx = getCtx();
   const t = tyId(ctx, ty);
   const p = boolId(ctx, cond);
-  const a = valId(ctx, t, then as Value);
-  const b = valId(ctx, t, els as Value);
+  const a = valId(ctx, t, then);
+  const b = valId(ctx, t, els);
   return idVal(ctx, t, ctx.block.select(ctx.func, p, t, a, b)) as ToSymbolic<T>;
 };
 
@@ -452,83 +501,83 @@ const realId = (ctx: Context, x: Real): number =>
 /** Return the negative of the abstract number `x`. */
 export const neg = (x: Real): Real => {
   const ctx = getCtx();
-  return new Var(ctx.block.neg(ctx.func, realId(ctx, x)));
+  return newVar(ctx.block.neg(ctx.func, realId(ctx, x)));
 };
 
 /** Return the absolute value of the abstract number `x`. */
 export const abs = (x: Real): Real => {
   const ctx = getCtx();
-  return new Var(ctx.block.abs(ctx.func, realId(ctx, x)));
+  return newVar(ctx.block.abs(ctx.func, realId(ctx, x)));
 };
 
 /** Return the square root of the abstract number `x`. */
 export const sqrt = (x: Real): Real => {
   const ctx = getCtx();
-  return new Var(ctx.block.sqrt(ctx.func, realId(ctx, x)));
+  return newVar(ctx.block.sqrt(ctx.func, realId(ctx, x)));
 };
 
 /** Return the abstract number `x` plus the abstract number `y`. */
 export const add = (x: Real, y: Real): Real => {
   const ctx = getCtx();
-  return new Var(ctx.block.add(ctx.func, realId(ctx, x), realId(ctx, y)));
+  return newVar(ctx.block.add(ctx.func, realId(ctx, x), realId(ctx, y)));
 };
 
 /** Return the abstract number `x` minus the abstract number `y`. */
 export const sub = (x: Real, y: Real): Real => {
   const ctx = getCtx();
-  return new Var(ctx.block.sub(ctx.func, realId(ctx, x), realId(ctx, y)));
+  return newVar(ctx.block.sub(ctx.func, realId(ctx, x), realId(ctx, y)));
 };
 
 /** Return the abstract number `x` times the abstract number `y`. */
 export const mul = (x: Real, y: Real): Real => {
   const ctx = getCtx();
-  return new Var(ctx.block.mul(ctx.func, realId(ctx, x), realId(ctx, y)));
+  return newVar(ctx.block.mul(ctx.func, realId(ctx, x), realId(ctx, y)));
 };
 
 /** Return the abstract number `x` divided by the abstract number `y`. */
 export const div = (x: Real, y: Real): Real => {
   const ctx = getCtx();
-  return new Var(ctx.block.div(ctx.func, realId(ctx, x), realId(ctx, y)));
+  return newVar(ctx.block.div(ctx.func, realId(ctx, x), realId(ctx, y)));
 };
 
 /** Return an abstract boolean for if `x` is not equal to `y`. */
 export const neq = (x: Real, y: Real): Bool => {
   const ctx = getCtx();
-  return new Var(ctx.block.neq(ctx.func, realId(ctx, x), realId(ctx, y)));
+  return newVar(ctx.block.neq(ctx.func, realId(ctx, x), realId(ctx, y)));
 };
 
 /** Return an abstract boolean for if `x` is less than `y`. */
 export const lt = (x: Real, y: Real): Bool => {
   const ctx = getCtx();
-  return new Var(ctx.block.lt(ctx.func, realId(ctx, x), realId(ctx, y)));
+  return newVar(ctx.block.lt(ctx.func, realId(ctx, x), realId(ctx, y)));
 };
 
 /** Return an abstract boolean for if `x` is less than or equal to `y`. */
 export const leq = (x: Real, y: Real): Bool => {
   const ctx = getCtx();
-  return new Var(ctx.block.leq(ctx.func, realId(ctx, x), realId(ctx, y)));
+  return newVar(ctx.block.leq(ctx.func, realId(ctx, x), realId(ctx, y)));
 };
 
 /** Return an abstract boolean for if `x` is equal to `y`. */
 export const eq = (x: Real, y: Real): Bool => {
   const ctx = getCtx();
-  return new Var(ctx.block.eq(ctx.func, realId(ctx, x), realId(ctx, y)));
+  return newVar(ctx.block.eq(ctx.func, realId(ctx, x), realId(ctx, y)));
 };
 
 /** Return an abstract boolean for if `x` is greater than `y`. */
 export const gt = (x: Real, y: Real): Bool => {
   const ctx = getCtx();
-  return new Var(ctx.block.gt(ctx.func, realId(ctx, x), realId(ctx, y)));
+  return newVar(ctx.block.gt(ctx.func, realId(ctx, x), realId(ctx, y)));
 };
 
 /** Return an abstract boolean for if `x` is greater than or equal to `y`. */
 export const geq = (x: Real, y: Real): Bool => {
   const ctx = getCtx();
-  return new Var(ctx.block.geq(ctx.func, realId(ctx, x), realId(ctx, y)));
+  return newVar(ctx.block.geq(ctx.func, realId(ctx, x), realId(ctx, y)));
 };
 
 /** Return an abstract vector by computing each element via `f`. */
-export const vec = <I extends Type, T extends Type>(
+export const vec = <I, T>(
   index: I,
   elem: T,
   f: (i: ToSymbolic<I>) => ToValue<T>,
@@ -543,7 +592,7 @@ export const vec = <I extends Type, T extends Type>(
   const body = new wasm.Block();
   try {
     ctx.block = body;
-    out = valId(ctx, e, f(idVal(ctx, i, arg) as ToSymbolic<I>) as Value);
+    out = valId(ctx, e, f(idVal(ctx, i, arg) as ToSymbolic<I>));
   } finally {
     if (out === undefined) body.free();
     ctx.block = block;

--- a/packages/core/src/impl.ts
+++ b/packages/core/src/impl.ts
@@ -490,7 +490,7 @@ export const xor = (p: Bool, q: Bool): Bool => {
 };
 
 /** Return an abstract value selecting between `then` and `els` via `cond`. */
-export const select = <T>(
+export const select = <const T>(
   cond: Bool,
   ty: T,
   then: ToValue<T>,
@@ -587,7 +587,7 @@ export const geq = (x: Real, y: Real): Bool => {
 };
 
 /** Return an abstract vector by computing each element via `f`. */
-export const vec = <I, T>(
+export const vec = <const I, const T>(
   index: I,
   elem: T,
   f: (i: ToSymbolic<I>) => ToValue<T>,

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -248,4 +248,23 @@ describe("valid", () => {
     const h = interp(fn([], Real, () => f(g(3, 5))));
     expect(h()).toBe(2);
   });
+
+  test("return struct", () => {
+    const f = fn([], { p: Bool, x: Real }, () => ({ p: true, x: 42 }));
+    const g = interp(f);
+    expect(g()).toEqual({ p: true, x: 42 });
+  });
+
+  test("array of structs", () => {
+    const n = 2;
+    const Indexed = { i: n, x: Real } as const;
+    const f = fn([Vec(n, Real)], Vec(n, Indexed), (v) =>
+      vec(n, Indexed, (i) => ({ i, x: v[i] })),
+    );
+    const h = interp(fn([], Vec(n, Indexed), () => f([3, 5])));
+    expect(h()).toEqual([
+      { i: 0, x: 3 },
+      { i: 1, x: 5 },
+    ]);
+  });
 });

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -276,7 +276,7 @@ describe("valid", () => {
     ]);
   });
 
-  test("internal struct of arrays", () => {
+  test("internal array of structs", () => {
     const n = 2;
     const f = fn([Vec(n, Real)], Vec(n, n), (v) => {
       const u = vec(n, { i: n }, (i) => ({ i }));

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -17,19 +17,15 @@ import {
 
 describe("invalid", () => {
   test("undefined", () => {
-    expect(() => fn([], Real, () => undefined as any)).toThrow(
-      "undefined value",
-    );
+    expect(() => fn([], Real, () => undefined as any)).toThrow("invalid value");
   });
 
   test("bigint", () => {
-    expect(() => fn([], Real, () => 0n as any)).toThrow("bigint not supported");
+    expect(() => fn([], Real, () => 0n as any)).toThrow("invalid value");
   });
 
   test("string", () => {
-    expect(() => fn([], Real, () => "hello" as any)).toThrow(
-      "string not supported",
-    );
+    expect(() => fn([], Real, () => "hello" as any)).toThrow("invalid value");
   });
 
   test("literal return type", () => {
@@ -132,13 +128,6 @@ describe("valid", () => {
     const f = fn([], Vec(0, Real), () => []);
     const g = interp(f);
     expect(g()).toEqual([]);
-  });
-
-  test("singleton array", () => {
-    const f = fn([Real], Vec(1, Real), (x) => [x]);
-    const g = fn([], Vec(1, Real), () => f(42));
-    const h = interp(g);
-    expect(h()).toEqual([42]);
   });
 
   test("dot product", () => {
@@ -250,5 +239,13 @@ describe("valid", () => {
     const f = fn([], One, () => vec(1, One, (i) => [i])[0]);
     const g = interp(f);
     expect(g()).toEqual([0]);
+  });
+
+  test("struct", () => {
+    const Pair = { x: Real, y: Real } as const;
+    const f = fn([Pair], Real, (p) => sub(p.y, p.x));
+    const g = fn([Real, Real], Pair, (x, y) => ({ y, x }));
+    const h = interp(fn([], Real, () => f(g(3, 5))));
+    expect(h()).toBe(2);
   });
 });

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -76,6 +76,12 @@ describe("invalid", () => {
       }),
     ).toThrow("variable is out of scope");
   });
+
+  test("wrong struct member names", () => {
+    expect(() =>
+      fn([{ a: Real, b: Real }], { b: Real, c: Real }, (x) => x as any),
+    ).toThrow("variable type mismatch");
+  });
 });
 
 describe("valid", () => {

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -255,16 +255,34 @@ describe("valid", () => {
     expect(g()).toEqual({ p: true, x: 42 });
   });
 
+  test("select struct", () => {
+    const f = fn([], Real, () => {
+      return select(false, { x: Real }, { x: 3 }, { x: 5 }).x;
+    });
+    const g = interp(f);
+    expect(g()).toBe(5);
+  });
+
   test("array of structs", () => {
     const n = 2;
     const Indexed = { i: n, x: Real } as const;
     const f = fn([Vec(n, Real)], Vec(n, Indexed), (v) =>
       vec(n, Indexed, (i) => ({ i, x: v[i] })),
     );
-    const h = interp(fn([], Vec(n, Indexed), () => f([3, 5])));
-    expect(h()).toEqual([
+    const g = interp(fn([], Vec(n, Indexed), () => f([3, 5])));
+    expect(g()).toEqual([
       { i: 0, x: 3 },
       { i: 1, x: 5 },
     ]);
+  });
+
+  test("internal struct of arrays", () => {
+    const n = 2;
+    const f = fn([Vec(n, Real)], Vec(n, n), (v) => {
+      const u = vec(n, { i: n }, (i) => ({ i }));
+      return vec(n, n, (i) => u[i].i);
+    });
+    const g = interp(fn([], Vec(n, n), () => f([3, 5])));
+    expect(g()).toEqual([0, 1]);
   });
 });


### PR DESCRIPTION
Resolves #34. By following up on the strategy from #68, it turns out to be totally fine to just use unadorned object literal notation, because we got rid of typedefs in #54 and now we deduplicate types using a hash map; and also we can just determine the types of all a struct's members by looking at the type we expect it to be in the context where it is used.