### PR TITLE
Clean up

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,7 +264,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19be8061a06ab6f3a6cf21106c873578bf01bd42ad15e0311a9c76161cb1c753"
 dependencies = [
  "enumset_derive",
- "serde",
 ]
 
 [[package]]
@@ -377,7 +376,6 @@ checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.0",
- "serde",
 ]
 
 [[package]]
@@ -630,9 +628,6 @@ name = "rose"
 version = "0.0.0"
 dependencies = [
  "enumset",
- "serde",
- "thiserror",
- "ts-rs",
 ]
 
 [[package]]
@@ -691,7 +686,6 @@ dependencies = [
  "rose-interp",
  "serde",
  "serde-wasm-bindgen",
- "ts-rs",
  "wasm-bindgen",
 ]
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -8,12 +8,3 @@ include = ["src/lib.rs"]
 
 [dependencies]
 enumset = "1"
-serde = { version = "1", features = ["derive"], optional = true }
-thiserror = "1"
-
-[dev-dependencies]
-ts-rs = "6"
-
-[features]
-default = ["serde"]
-serde = ["dep:serde", "enumset/serde"]

--- a/crates/core/src/id.rs
+++ b/crates/core/src/id.rs
@@ -1,18 +1,4 @@
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-
-// remember to `serde(rename)` everything here to avoid ts-rs name conflicts with non-ID types
-
-#[cfg(test)]
-use ts_rs::TS;
-
 /// Index of a member in a tuple.
-#[cfg_attr(test, derive(TS), ts(export))]
-#[cfg_attr(
-    feature = "serde",
-    derive(Serialize, Deserialize),
-    serde(rename = "MemberId")
-)]
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Member(usize);
 
@@ -27,32 +13,20 @@ impl Member {
 }
 
 /// Index of an uninstantiated function reference in a definition context.
-#[cfg_attr(test, derive(TS), ts(export))]
-#[cfg_attr(
-    feature = "serde",
-    derive(Serialize, Deserialize),
-    serde(rename = "FunctionId")
-)]
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct Function(usize);
+pub struct Func(usize);
 
-pub fn function(id: usize) -> Function {
-    Function(id)
+pub fn func(id: usize) -> Func {
+    Func(id)
 }
 
-impl Function {
-    pub fn function(self) -> usize {
+impl Func {
+    pub fn func(self) -> usize {
         self.0
     }
 }
 
 /// Index of a generic type parameter in a definition context.
-#[cfg_attr(test, derive(TS), ts(export))]
-#[cfg_attr(
-    feature = "serde",
-    derive(Serialize, Deserialize),
-    serde(rename = "GenericId")
-)]
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Generic(usize);
 
@@ -67,12 +41,6 @@ impl Generic {
 }
 
 /// Index of a type in a definition context.
-#[cfg_attr(test, derive(TS), ts(export))]
-#[cfg_attr(
-    feature = "serde",
-    derive(Serialize, Deserialize),
-    serde(rename = "TyId")
-)]
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Ty(usize);
 
@@ -87,12 +55,6 @@ impl Ty {
 }
 
 /// Index of a local variable in a function definition context.
-#[cfg_attr(test, derive(TS), ts(export))]
-#[cfg_attr(
-    feature = "serde",
-    derive(Serialize, Deserialize),
-    serde(rename = "VarId")
-)]
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Var(usize);
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -2,15 +2,7 @@ pub mod id;
 
 use enumset::{EnumSet, EnumSetType};
 
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-
-#[cfg(test)]
-use ts_rs::TS;
-
 /// A type constraint.
-#[cfg_attr(test, derive(TS), ts(export))]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[allow(clippy::derived_hash_with_manual_eq)] // `PartialEq` impl comes from enumset; should be fine
 #[derive(Debug, EnumSetType, Hash)]
 pub enum Constraint {
@@ -25,8 +17,6 @@ pub enum Constraint {
 }
 
 /// A type.
-#[cfg_attr(test, derive(TS), ts(export))]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum Ty {
     Unit,
@@ -55,13 +45,13 @@ pub enum Ty {
         elem: id::Ty,
     },
     Tuple {
-        members: Vec<id::Ty>, // TODO: change to `Box<[id::Ty]`
+        members: Box<[id::Ty]>,
     },
 }
 
 /// A function definition.
 #[derive(Debug)]
-pub struct Function {
+pub struct Func {
     /// Generic type parameters.
     pub generics: Box<[EnumSet<Constraint>]>,
     /// Types used in this function definition.
@@ -76,13 +66,13 @@ pub struct Function {
     pub body: Box<[Instr]>,
 }
 
-/// Resolves `id::Function`s.
+/// Resolves `id::Func`s.
 pub trait Refs<'a> {
     /// See `Node`.
     type Opaque;
 
     /// Resolve `id` to a function node.
-    fn get(&self, id: id::Function) -> Option<Node<'a, Self::Opaque, Self>>
+    fn get(&self, id: id::Func) -> Option<Node<'a, Self::Opaque, Self>>
     where
         Self: Sized;
 }
@@ -95,7 +85,7 @@ pub enum Node<'a, O, T: Refs<'a, Opaque = O>> {
         /// To traverse the graph by resolving functions called by this one.
         refs: T,
         /// The signature and definition of this function.
-        def: &'a Function,
+        def: &'a Func,
     },
     /// A function with an opaque body.
     Opaque {
@@ -112,14 +102,12 @@ pub enum Node<'a, O, T: Refs<'a, Opaque = O>> {
     },
 }
 
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub struct Instr {
     pub var: id::Var,
     pub expr: Expr,
 }
 
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub enum Expr {
     Unit,
@@ -177,7 +165,7 @@ pub enum Expr {
     },
 
     Call {
-        id: id::Function,
+        id: id::Func,
         generics: Box<[id::Ty]>,
         args: Box<[id::Var]>,
     },
@@ -223,8 +211,6 @@ pub enum Expr {
     },
 }
 
-#[cfg_attr(test, derive(TS), ts(export))]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum Unop {
     // `Bool` -> `Bool`
@@ -236,8 +222,6 @@ pub enum Unop {
     Sqrt,
 }
 
-#[cfg_attr(test, derive(TS), ts(export))]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum Binop {
     // `Bool` -> `Bool` -> `Bool`

--- a/crates/frontend/src/translate.rs
+++ b/crates/frontend/src/translate.rs
@@ -110,7 +110,7 @@ pub struct Typedef<'input> {
 #[derive(Debug)]
 pub struct Module<'input> {
     types: IndexMap<&'input str, Typedef<'input>>,
-    funcs: IndexMap<&'input str, rose::Function>,
+    funcs: IndexMap<&'input str, rose::Func>,
 }
 
 type Opaque = Infallible;
@@ -118,9 +118,9 @@ type Opaque = Infallible;
 impl<'input, 'a> rose::Refs<'a> for &'a Module<'input> {
     type Opaque = Opaque;
 
-    fn get(&self, id: id::Function) -> Option<ir::Node<'a, Opaque, Self>> {
+    fn get(&self, id: id::Func) -> Option<ir::Node<'a, Opaque, Self>> {
         self.funcs
-            .get_index(id.function())
+            .get_index(id.func())
             .map(|(_, def)| ir::Node::Transparent { refs: *self, def })
     }
 }
@@ -132,7 +132,7 @@ impl Module<'_> {
 
     pub fn get_func(&self, name: &str) -> Option<ir::Node<Opaque, &Module>> {
         let i = self.funcs.get_index_of(name)?;
-        ir::Refs::get(&self, id::function(i))
+        ir::Refs::get(&self, id::func(i))
     }
 }
 
@@ -183,7 +183,7 @@ impl<'input, 'a> BlockCtx<'input, 'a> {
 
     fn unify(
         &mut self,
-        _f: &ir::Function,
+        _f: &ir::Func,
         _args: &[id::Ty],
     ) -> Result<(Vec<id::Ty>, id::Ty), TypeError> {
         todo!()
@@ -271,7 +271,7 @@ impl<'input, 'a> BlockCtx<'input, 'a> {
                     Ok(self.instr(
                         ret,
                         ir::Expr::Call {
-                            id: id::function(i),
+                            id: id::func(i),
                             generics: generics.into(),
                             args: vars,
                         },
@@ -425,7 +425,7 @@ impl<'input> Module<'input> {
                     ctx.bind(bind, id::var(i));
                 }
                 let retvar = ctx.typecheck(body)?; // TODO: ensure this matches `ret`
-                let f = ir::Function {
+                let f = ir::Func {
                     generics,
                     types: ctx.t.into_iter().collect(),
                     vars: ctx.v.into(),

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -10,13 +10,12 @@ crate-type = ["cdylib"]
 [dependencies]
 console_error_panic_hook = { version = "0.1", optional = true }
 enumset = "1"
-indexmap = { version = "2", features = ["serde"] }
+indexmap = "2"
 js-sys = "0.3"
-rose = { path = "../core", features = ["serde"] }
+rose = { path = "../core" }
 rose-interp = { path = "../interp", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde-wasm-bindgen = "0.4"
-ts-rs = "6"
 wasm-bindgen = "=0.2.87" # Must be this version of wbg
 
 [features]

--- a/packages/core/src/impl.test.ts
+++ b/packages/core/src/impl.test.ts
@@ -35,9 +35,9 @@ test("core IR type layouts", () => {
   // these don't matter too much, but it's good to notice if sizes increase
   expect(Object.fromEntries(wasm.layouts())).toEqual({
     Expr: { size: 24, align: 8 },
-    Function: { size: 44, align: 4 },
+    Func: { size: 44, align: 4 },
     Instr: { size: 32, align: 8 },
-    Ty: { size: 16, align: 4 },
+    Ty: { size: 12, align: 4 },
   });
 });
 


### PR DESCRIPTION
This PR cleans up several things:

- remove a bunch of unnecessary dependencies, especially from `crates/core`
- rename `rose::Function` to `rose::Func`
- change the type of `members` in `rose::Ty::Tuple` from `Vec<rose::id::Ty>` to `Box<[rose::id::Ty]>`