### PR TITLE
Flatten reference scopes

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -176,25 +176,16 @@ pub enum Expr {
         /// Variable from `body` holding an array element.
         ret: id::Var,
     },
-    /// Scope for a `Ref` with `Constraint::Read`. Returns `Unit`.
+
+    /// Start a scope for a `Ref` with `Constraint::Read`.
     Read {
         /// Contents of the `Ref`.
         var: id::Var,
-        /// Has type `Ref` with scope `arg` and inner type same as `var`.
-        arg: id::Var,
-        body: Box<[Instr]>,
-        /// Variable from `body` holding the result of this block; escapes into outer scope.
-        ret: id::Var,
     },
-    /// Scope for a `Ref` with `Constraint::Accum`. Returns the final contents of the `Ref`.
+    /// Start a scope for a `Ref` with `Constraint::Accum`.
     Accum {
         /// Topology of the `Ref`.
         shape: id::Var,
-        /// Has type `Ref` with scope `arg` and inner type same as `shape`.
-        arg: id::Var,
-        body: Box<[Instr]>,
-        /// Variable from `body` holding the result of this block; escapes into outer scope.
-        ret: id::Var,
     },
 
     /// Read from a `Ref` whose `scope` satisfies `Constraint::Read`.
@@ -208,6 +199,12 @@ pub enum Expr {
         accum: id::Var,
         /// Must be of the `Ref`'s inner type.
         addend: id::Var,
+    },
+
+    /// Consume a `Ref` to get its contained value.
+    Resolve {
+        /// The `Ref`, which must be in scope.
+        var: id::Var,
     },
 }
 

--- a/crates/interp/src/lib.rs
+++ b/crates/interp/src/lib.rs
@@ -256,32 +256,17 @@ impl<'a, 'b, O: Opaque, T: Refs<'a, Opaque = O>> Interpreter<'a, 'b, O, T> {
                     (0..n).map(|i| self.block(*arg, body, *ret, Val::Fin(i)).clone()),
                 ))
             }
-            Expr::Read {
-                var,
-                arg,
-                body,
-                ret,
-            } => {
-                let r = Val::Ref(Rc::new(self.get(*var).clone()));
-                self.block(*arg, body, *ret, r);
-                Val::Unit
-            }
-            Expr::Accum {
-                shape,
-                arg,
-                body,
-                ret,
-            } => {
-                let x = Val::Ref(Rc::new(self.get(*shape).zero()));
-                self.block(*arg, body, *ret, x.clone());
-                x.inner().clone()
-            }
+
+            &Expr::Read { var } => Val::Ref(Rc::new(self.get(var).clone())),
+            &Expr::Accum { shape } => Val::Ref(Rc::new(self.get(shape).zero())),
 
             &Expr::Ask { var } => self.get(var).inner().clone(),
             &Expr::Add { accum, addend } => {
                 self.get(accum).inner().add(self.get(addend));
                 Val::Unit
             }
+
+            &Expr::Resolve { var } => self.get(var).inner().clone(),
         }
     }
 

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -384,46 +384,13 @@ pub fn pprint(f: &Func) -> Result<String, JsError> {
                 }
                 writeln!(&mut s, "}}")?
             }
-            rose::Expr::Read {
-                var,
-                arg,
-                body,
-                ret,
-            } => {
-                writeln!(&mut s, "read x{} {{", var.var())?;
-                for _ in 0..spaces {
-                    write!(&mut s, " ")?;
-                }
-                let x = arg.var();
-                writeln!(&mut s, "  x{x}: T{}", def.vars[x].ty())?;
-                print_block(s, def, spaces + 2, body, *ret)?;
-                for _ in 0..spaces {
-                    write!(&mut s, " ")?;
-                }
-                writeln!(&mut s, "}}")?
-            }
-            rose::Expr::Accum {
-                shape,
-                arg,
-                body,
-                ret,
-            } => {
-                writeln!(&mut s, "accum x{} {{", shape.var())?;
-                for _ in 0..spaces {
-                    write!(&mut s, " ")?;
-                }
-                let x = arg.var();
-                writeln!(&mut s, "  x{x}: T{}", def.vars[x].ty())?;
-                print_block(s, def, spaces + 2, body, *ret)?;
-                for _ in 0..spaces {
-                    write!(&mut s, " ")?;
-                }
-                writeln!(&mut s, "}}")?
-            }
+            rose::Expr::Read { var } => writeln!(&mut s, "read x{}", var.var())?,
+            rose::Expr::Accum { shape } => writeln!(&mut s, "accum x{}", shape.var())?,
             rose::Expr::Ask { var } => writeln!(&mut s, "ask x{}", var.var())?,
             rose::Expr::Add { accum, addend } => {
                 writeln!(&mut s, "x{} += x{}", accum.var(), addend.var())?
             }
+            rose::Expr::Resolve { var } => writeln!(&mut s, "resolve x{}", var.var())?,
         }
         Ok(())
     }
@@ -1121,12 +1088,6 @@ impl Block {
             let var = instr.var;
             code.push(instr);
             f.extra(var, code);
-            match &code.last().unwrap().expr {
-                &rose::Expr::Read { ret, .. } | &rose::Expr::Accum { ret, .. } => {
-                    f.extra(ret, code);
-                }
-                _ => {}
-            }
         }
     }
 


### PR DESCRIPTION
Now that we've restricted `Ref`s to parameters and local variables as of #64, there's no real reason for instructions introducing `Ref` scopes to require their own blocks; we can just introduce the scope in an instruction and then resolve it in another instruction later in the same block. I think I had also previously thought that this would make validation harder in #53, but now I no longer think that's the case; all you need to do is mark reference variables using the same scope as expired once you reach the "resolve" instruction. Anyway, this will make #86 easier because it means that a function's level of nesting can no longer drastically increase during transposition.