### PR TITLE
Pretty-print scopes as variables

### DIFF
--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -455,7 +455,7 @@ pub fn pprint(f: &Func) -> Result<String, JsError> {
             rose::Ty::Unit | rose::Ty::Bool | rose::Ty::F64 => writeln!(&mut s, "{ty:?}")?,
             rose::Ty::Fin { size } => writeln!(&mut s, "{size}")?,
             rose::Ty::Generic { id } => writeln!(&mut s, "G{}", id.generic())?,
-            rose::Ty::Scope { kind, id } => writeln!(&mut s, "B{}: {kind:?}", id.var())?,
+            rose::Ty::Scope { kind, id } => writeln!(&mut s, "x{}: {kind:?}", id.var())?,
             rose::Ty::Ref { scope, inner } => {
                 writeln!(&mut s, "Ref T{} T{}", scope.ty(), inner.ty())?
             }


### PR DESCRIPTION
When we merged #64, we forgot to change `pprint` to reflect the fact that scopes now refer to variables instead of blocks.