### PR TITLE
Pretty-print tuple access with brackets

### DIFF
--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -330,13 +330,13 @@ pub fn pprint(f: &Func) -> Result<String, JsError> {
                 writeln!(&mut s, "x{}[x{}]", array.var(), index.var())?
             }
             rose::Expr::Member { tuple, member } => {
-                writeln!(&mut s, "x{}.{}", tuple.var(), member.member())?
+                writeln!(&mut s, "x{}[{}]", tuple.var(), member.member())?
             }
             rose::Expr::Slice { array, index } => {
                 writeln!(&mut s, "x{}![x{}]", array.var(), index.var())?
             }
             rose::Expr::Field { tuple, member } => {
-                writeln!(&mut s, "x{}!.{}", tuple.var(), member.member())?
+                writeln!(&mut s, "x{}![{}]", tuple.var(), member.member())?
             }
             rose::Expr::Unary { op, arg } => match op {
                 rose::Unop::Not => writeln!(&mut s, "not x{}", arg.var())?,


### PR DESCRIPTION
Currently tuple member accesses are a bit hard to read because variable identifiers always end with a number, so they look too much like floating point literals.