### PR TITLE
Allow compiled functions to share memory

### DIFF
--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -330,9 +330,14 @@ impl Func {
 
     /// Compile the call graph subtended by this function to WebAssembly.
     pub fn compile(&self) -> Wasm {
-        let rose_wasm::Wasm { bytes, imports } = rose_wasm::compile(self.node());
+        let rose_wasm::Wasm {
+            bytes,
+            pages,
+            imports,
+        } = rose_wasm::compile(self.node());
         Wasm {
             bytes: Some(bytes),
+            pages,
             imports: Some(
                 imports
                     .into_keys()
@@ -488,6 +493,7 @@ impl Func {
 #[wasm_bindgen]
 pub struct Wasm {
     bytes: Option<Vec<u8>>,
+    pub pages: u64,
     imports: Option<Vec<js_sys::Function>>,
 }
 

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -656,12 +656,12 @@ describe("valid", () => {
     expect(memory.buffer.byteLength).toBeGreaterThan(pageSize);
     const a = [];
     const b = [];
-    for (let i = 0; i < n; ++i) {
+    for (let i = 1; i <= n; ++i) {
       a.push(i);
       b.push(1 / i);
     }
     const c = gCompiled(a, b);
-    for (let i = 0; i < n; ++i) expect(c[i]).toBe(1);
+    for (let i = 0; i < n; ++i) expect(c[i]).toBeCloseTo(1);
   });
 
   test("compile opaque function", async () => {


### PR DESCRIPTION
Currently every function created using `compile` allocates its own memory. This causes problems in applications that call `compile` many times, because current browsers do not consistently track the amount of allocated Wasm memory with their garbage collectors, and so out-of-memory errors can easily result even if the amount of memory needed at a given time is relatively small.

This PR addresses the issue by allowing the `compile` function to take in an optional `memory` parameter, which it will use (and grow if necessary) if provided, instead of always allocating a new memory.